### PR TITLE
fix: add missing Prod env vars to Cloud Run deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,5 +60,7 @@ jobs:
             DATABASE_USERNAME=${{ secrets.DATABASE_USERNAME }}
             DATABASE_PASSWORD=${{ secrets.DATABASE_PASSWORD }}
             GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}
+            GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }}
+            GOOGLE_REFRESH_TOKEN=${{ secrets.GOOGLE_REFRESH_TOKEN }}
             GOOGLE_DRIVE_FOLDER_ID=${{ secrets.GOOGLE_DRIVE_FOLDER_ID }}
           flags: '--allow-unauthenticated'

--- a/src/main/kotlin/com/jankowski/rafal/dancebook/service/GoogleDriveService.kt
+++ b/src/main/kotlin/com/jankowski/rafal/dancebook/service/GoogleDriveService.kt
@@ -27,6 +27,18 @@ class GoogleDriveService(
         val clientSecret = driveProperties.clientSecret.trim()
         val refreshToken = driveProperties.refreshToken.trim()
 
+        if (clientId.isBlank() || clientSecret.isBlank() || refreshToken.isBlank()) {
+            val missing = mutableListOf<String>()
+            if (clientId.isBlank()) missing.add("GOOGLE_CLIENT_ID")
+            if (clientSecret.isBlank()) missing.add("GOOGLE_CLIENT_SECRET")
+            if (refreshToken.isBlank()) missing.add("GOOGLE_REFRESH_TOKEN")
+            
+            val errorMsg = "CRITICAL: Missing required Google Drive properties: ${missing.joinToString()}. " +
+                           "Check your Environment Variables / GitHub Secrets!"
+            logger.error(errorMsg)
+            throw IllegalStateException(errorMsg)
+        }
+
         UserCredentials.newBuilder()
             .setClientId(clientId)
             .setClientSecret(clientSecret)


### PR DESCRIPTION
- Update deploy.yml to include GOOGLE_CLIENT_SECRET and GOOGLE_REFRESH_TOKEN
- Add fail-fast validation in GoogleDriveService to log missing variables