### PR TITLE
Make the training calendar work on a phone, and dress it in the app's own style

### DIFF
--- a/src/main/kotlin/com/jankowski/rafal/dancebook/controller/TrainingEventPalette.kt
+++ b/src/main/kotlin/com/jankowski/rafal/dancebook/controller/TrainingEventPalette.kt
@@ -1,0 +1,55 @@
+package com.jankowski.rafal.dancebook.controller
+
+import com.jankowski.rafal.dancebook.model.AttendanceStatus
+import com.jankowski.rafal.dancebook.model.TrainingEvent
+
+/**
+ * The one place a training session's status becomes a colour.
+ *
+ * Shared by the calendar feed and the legend the calendar page draws, which were previously
+ * two copies of the same five hex values that had to be kept in sync by hand.
+ *
+ * Values are Noble Harmony tokens, resolved here because neither JS nor a script-applied
+ * class name can reach Tailwind's palette at runtime.
+ */
+object TrainingEventPalette {
+
+    /** A status as the calendar draws it: solid colour for the stripe, tinted fill behind it. */
+    data class Swatch(
+        val key: String,
+        val label: String,
+        val color: String
+    ) {
+        /** The same colour at ~10% alpha, as an 8-digit hex the browser accepts directly. */
+        val tint: String get() = "$color$TINT_ALPHA"
+    }
+
+    /** ~10% opacity. Enough to read as a category, faint enough to keep text at full contrast. */
+    private const val TINT_ALPHA = "1a"
+
+    private const val COLOR_PLANNED = "#1e2524"      // primary-container
+    private const val COLOR_ATTENDED = "#2e5d51"     // success
+    private const val COLOR_SKIPPED = "#ba1a1a"      // danger
+    private const val COLOR_CANCELLED = "#737877"    // outline
+    private const val COLOR_UNCONFIRMED = "#695d46"  // secondary — wants attention
+
+    /** Text sits on the tint, not on the solid colour, so it stays on-surface throughout. */
+    const val TEXT_COLOR = "#1b1c1b"
+
+    val PLANNED = Swatch("planned", "Planned", COLOR_PLANNED)
+    val UNCONFIRMED = Swatch("unconfirmed", "Needs confirmation", COLOR_UNCONFIRMED)
+    val ATTENDED = Swatch("attended", "Attended", COLOR_ATTENDED)
+    val SKIPPED = Swatch("skipped", "Skipped", COLOR_SKIPPED)
+    val CANCELLED = Swatch("cancelled", "Cancelled", COLOR_CANCELLED)
+
+    /** Legend order, read left to right as a session's likely life: planned first, gone last. */
+    val LEGEND: List<Swatch> = listOf(PLANNED, UNCONFIRMED, ATTENDED, SKIPPED, CANCELLED)
+
+    fun swatchFor(event: TrainingEvent): Swatch = when {
+        event.isAwaitingConfirmation -> UNCONFIRMED
+        event.attendanceStatus == AttendanceStatus.ATTENDED -> ATTENDED
+        event.attendanceStatus == AttendanceStatus.SKIPPED -> SKIPPED
+        event.attendanceStatus == AttendanceStatus.CANCELLED -> CANCELLED
+        else -> PLANNED
+    }
+}

--- a/src/main/kotlin/com/jankowski/rafal/dancebook/controller/api/TrainingCalendarApiController.kt
+++ b/src/main/kotlin/com/jankowski/rafal/dancebook/controller/api/TrainingCalendarApiController.kt
@@ -1,6 +1,6 @@
 package com.jankowski.rafal.dancebook.controller.api
 
-import com.jankowski.rafal.dancebook.model.AttendanceStatus
+import com.jankowski.rafal.dancebook.controller.TrainingEventPalette
 import com.jankowski.rafal.dancebook.model.TrainingEvent
 import com.jankowski.rafal.dancebook.service.TrainingEventService
 import org.springframework.web.bind.annotation.GetMapping
@@ -14,25 +14,17 @@ import java.time.format.DateTimeParseException
 /**
  * Feeds the FullCalendar view.
  *
- * Colours are sent as hex rather than class names on purpose: Tailwind's content globs
- * cover the templates directory only, so a class name a script puts on an element is
- * never emitted into output.css and would silently render unstyled.
+ * Colours are sent as hex rather than class names because FullCalendar owns the chip element
+ * and the palette has to reach it as inline style. A chip is drawn as a tinted fill behind a
+ * solid leading stripe, so the feed sends both: [CalendarEventResponse.backgroundColor] is the
+ * tint, [CalendarEventResponse.borderColor] the solid colour the renderer uses for the stripe.
+ * All five values live in [TrainingEventPalette], shared with the legend on the page.
  */
 @RestController
 @RequestMapping("/api/training-events")
 class TrainingCalendarApiController(
     private val trainingEventService: TrainingEventService
 ) {
-
-    private companion object {
-        // Noble Harmony tokens, resolved here because JS cannot reach Tailwind's palette.
-        const val COLOR_PLANNED = "#1e2524"      // primary-container
-        const val COLOR_ATTENDED = "#2e5d51"     // success
-        const val COLOR_SKIPPED = "#ba1a1a"      // danger
-        const val COLOR_CANCELLED = "#737877"    // outline
-        const val COLOR_UNCONFIRMED = "#695d46"  // secondary — wants attention
-        const val TEXT_COLOR = "#ffffff"
-    }
 
     @GetMapping("/calendar")
     fun calendarFeed(
@@ -43,13 +35,7 @@ class TrainingCalendarApiController(
             .map { it.toCalendarEvent() }
 
     private fun TrainingEvent.toCalendarEvent(): CalendarEventResponse {
-        val colour = when {
-            isAwaitingConfirmation -> COLOR_UNCONFIRMED
-            attendanceStatus == AttendanceStatus.ATTENDED -> COLOR_ATTENDED
-            attendanceStatus == AttendanceStatus.SKIPPED -> COLOR_SKIPPED
-            attendanceStatus == AttendanceStatus.CANCELLED -> COLOR_CANCELLED
-            else -> COLOR_PLANNED
-        }
+        val swatch = TrainingEventPalette.swatchFor(this)
 
         return CalendarEventResponse(
             id = id.toString(),
@@ -59,10 +45,12 @@ class TrainingCalendarApiController(
             start = startTime.toString(),
             end = endTime.toString(),
             url = "/training-events/$id",
-            backgroundColor = colour,
-            borderColor = colour,
-            textColor = TEXT_COLOR,
+            backgroundColor = swatch.tint,
+            borderColor = swatch.color,
+            textColor = TrainingEventPalette.TEXT_COLOR,
             extendedProps = CalendarEventProps(
+                status = swatch.key,
+                statusLabel = swatch.label,
                 attendanceStatus = attendanceStatus.name,
                 awaitingConfirmation = isAwaitingConfirmation,
                 eventType = eventType.name,
@@ -97,6 +85,9 @@ data class CalendarEventResponse(
 )
 
 data class CalendarEventProps(
+    /** Palette key the chip renderer styles on: planned, unconfirmed, attended, skipped, cancelled. */
+    val status: String,
+    val statusLabel: String,
     val attendanceStatus: String,
     val awaitingConfirmation: Boolean,
     val eventType: String,

--- a/src/main/kotlin/com/jankowski/rafal/dancebook/controller/web/TrainingEventWebController.kt
+++ b/src/main/kotlin/com/jankowski/rafal/dancebook/controller/web/TrainingEventWebController.kt
@@ -1,8 +1,10 @@
 package com.jankowski.rafal.dancebook.controller.web
 
+import com.jankowski.rafal.dancebook.controller.TrainingEventPalette
 import com.jankowski.rafal.dancebook.dto.TrainingEventRequest
 import com.jankowski.rafal.dancebook.dto.TrainingEventSegmentRequest
 import com.jankowski.rafal.dancebook.model.AttendanceStatus
+import com.jankowski.rafal.dancebook.model.TrainingEvent
 import com.jankowski.rafal.dancebook.model.TrainingEventType
 import com.jankowski.rafal.dancebook.service.DanceCategoryService
 import com.jankowski.rafal.dancebook.service.TrainingEventService
@@ -25,6 +27,8 @@ import org.springframework.http.ResponseEntity
 import java.time.Duration
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.YearMonth
+import java.time.format.DateTimeFormatter
 import java.time.format.TextStyle
 import java.util.Locale
 import java.util.UUID
@@ -42,6 +46,8 @@ class TrainingEventWebController(
 
         /** Evening default for a day clicked in month view; most training is after work. */
         private const val DEFAULT_HOUR = 18
+
+        private val MONTH_LABEL: DateTimeFormatter = DateTimeFormatter.ofPattern("MMMM yyyy", Locale.ENGLISH)
     }
 
     @GetMapping
@@ -54,7 +60,7 @@ class TrainingEventWebController(
         model: Model
     ): String {
         val events = trainingEventService.findByCurrentUser(eventTypes, categoryIds, attendanceStatuses, search)
-        model.addAttribute("events", events)
+        populateEventsList(model, events)
         // ArrayList, not emptyList(): Kotlin's EmptyList is an internal object whose
         // members SpEL cannot reflect on, so contains(...) fails at template render time.
         model.addAttribute("selectedEventTypes", ArrayList(eventTypes ?: emptyList()))
@@ -68,6 +74,7 @@ class TrainingEventWebController(
             model.addAttribute("danceCategories", danceCategoryService.findAll())
             model.addAttribute("eventTypeOptions", TrainingEventType.entries.toTypedArray())
             model.addAttribute("attendanceStatusOptions", AttendanceStatus.entries.toTypedArray())
+            model.addAttribute("activeFilterCount", activeFilterCount(eventTypes, categoryIds, attendanceStatuses))
         }
 
         return if (isHtmxRequest == true) {
@@ -80,6 +87,8 @@ class TrainingEventWebController(
     @GetMapping("/calendar")
     fun showCalendar(model: Model): String {
         model.addAttribute("pageTitle", "Training calendar")
+        // The legend and the JSON feed read the same palette, so the two can never drift.
+        model.addAttribute("statusLegend", TrainingEventPalette.LEGEND)
         return "training-events/calendar"
     }
 
@@ -255,7 +264,7 @@ class TrainingEventWebController(
             return "redirect:/training-events/$id"
         }
 
-        model.addAttribute("events", trainingEventService.findByCurrentUser())
+        populateEventsList(model, trainingEventService.findByCurrentUser())
         return "training-events/list :: eventsList"
     }
 
@@ -272,9 +281,72 @@ class TrainingEventWebController(
         return "redirect:/training-events"
     }
 
+    /**
+     * Everything the `eventsList` fragment needs. Every path that renders it -- the full page,
+     * the HTMX filter swap and the attendance swap -- goes through here; a path that only set
+     * `events` would render the fragment with no month headings at all.
+     */
+    private fun populateEventsList(model: Model, events: List<TrainingEvent>) {
+        model.addAttribute("events", events)
+        model.addAttribute("monthGroups", groupByMonth(events))
+    }
+
+    /** Drives the "Filters" badge on the collapsed mobile filter panel. */
+    private fun activeFilterCount(vararg selections: Collection<*>?): Int =
+        selections.count { !it.isNullOrEmpty() }
+
+    /**
+     * A training log is read in months: how many sessions, how many hours. Grouping happens
+     * here rather than in the template because Thymeleaf can only compare a row against its
+     * predecessor, which makes the totals awkward and the markup worse.
+     */
+    private fun groupByMonth(events: List<TrainingEvent>): List<TrainingMonthGroup> =
+        events.groupBy { YearMonth.from(it.startTime) }
+            .map { (month, monthEvents) ->
+                TrainingMonthGroup(
+                    label = month.format(MONTH_LABEL),
+                    rows = monthEvents.map { TrainingEventRow(it, TrainingEventPalette.swatchFor(it)) },
+                    totalMinutes = monthEvents.sumOf { it.durationMinutes }
+                )
+            }
+
     private fun populateFormOptions(model: Model) {
         model.addAttribute("danceCategories", danceCategoryService.findAll())
         model.addAttribute("eventTypeOptions", TrainingEventType.entries.toTypedArray())
         model.addAttribute("attendanceStatusOptions", AttendanceStatus.entries.toTypedArray())
     }
+}
+
+/**
+ * A session as the agenda draws it. The swatch travels with the event so the template never
+ * has to re-derive a colour from a status, which is how the palette came to be duplicated.
+ */
+data class TrainingEventRow(
+    val event: TrainingEvent,
+    val swatch: TrainingEventPalette.Swatch
+)
+
+/**
+ * One month of the agenda, with the totals that make a training log worth grouping.
+ */
+data class TrainingMonthGroup(
+    val label: String,
+    val rows: List<TrainingEventRow>,
+    val totalMinutes: Long
+) {
+    val sessionCount: Int get() = rows.size
+
+    val sessionLabel: String get() = if (sessionCount == 1) "1 session" else "$sessionCount sessions"
+
+    /** "9h 30m", "45m", "3h" -- whichever parts are non-zero. */
+    val totalLabel: String
+        get() {
+            val hours = totalMinutes / 60
+            val minutes = totalMinutes % 60
+            return when {
+                hours == 0L -> "${minutes}m"
+                minutes == 0L -> "${hours}h"
+                else -> "${hours}h ${minutes}m"
+            }
+        }
 }

--- a/src/main/resources/frontend/input.css
+++ b/src/main/resources/frontend/input.css
@@ -93,7 +93,9 @@
            text-sm font-semibold whitespace-nowrap;
   }
   .badge-primary {
-    @apply badge bg-primary-soft text-on-surface border border-border;
+    /* on-surface here is #1b1c1b against a #1e2524 pill -- near-black on near-black.
+       The container colour's own paired on-colour is what makes the label readable. */
+    @apply badge bg-primary-soft text-on-primary-container border border-border;
   }
   .badge-secondary {
     @apply badge bg-surface-container-high text-on-surface border border-border;
@@ -300,6 +302,95 @@
   .icon-filled {
     font-variation-settings: 'FILL' 1;
   }
+
+  /* ── Training calendar ───────────────────────────
+   * The chip is the one loud object on the calendar: a solid stripe in the status colour,
+   * a 10% tint of it behind, and the session's own detail. Everything around it stays
+   * hairline rules and whitespace. Stripe and tint arrive as inline colour from the feed.
+   * ─────────────────────────────────────────────── */
+  .tc-chip {
+    @apply block h-full overflow-hidden rounded-sm border-l-[3px] px-1.5 py-1 text-left leading-snug;
+  }
+  .tc-chip-time {
+    @apply block text-[11px] font-semibold tabular-nums text-on-surface-variant;
+  }
+  .tc-chip-title {
+    @apply block truncate text-[13px] font-semibold text-on-surface;
+  }
+  .tc-chip-styles {
+    @apply block truncate text-[11px] text-on-surface-variant;
+  }
+  .tc-chip-struck .tc-chip-title {
+    @apply line-through opacity-70;
+  }
+
+  /* Load dots stand in for chips in the month grid on phones, where a chip cannot be read. */
+  .tc-daydots {
+    @apply mt-0.5 flex flex-wrap items-center justify-center gap-[3px] px-0.5;
+  }
+  .tc-daydot {
+    @apply block h-[5px] w-[5px] shrink-0 rounded-full;
+  }
+
+  /* Selected-day agenda, below the month grid on phones. */
+  .tc-agenda-heading {
+    @apply flex items-baseline justify-between gap-3 border-b border-outline-variant/60 pb-2;
+  }
+  .tc-agenda-card {
+    @apply flex items-start gap-3 rounded-sm border border-l-[3px] border-outline-variant/60
+           bg-surface-container-lowest p-3 text-left;
+  }
+  .tc-agenda-time {
+    @apply w-[4.75rem] shrink-0 text-[13px] font-semibold tabular-nums text-on-surface-variant;
+  }
+  .tc-agenda-empty {
+    @apply rounded-sm border border-dashed border-outline-variant px-4 py-8 text-center
+           font-body-md text-body-md text-on-surface-variant;
+  }
+
+  /* Floating create button, clearing the fixed bottom nav. */
+  .tc-fab {
+    @apply fixed right-4 z-40 flex h-14 w-14 items-center justify-center rounded-full
+           bg-primary-container text-on-primary-container shadow-ambient
+           transition-transform duration-200 active:scale-95;
+    bottom: calc(5.5rem + env(safe-area-inset-bottom));
+  }
+
+  /* Quick create is an anchored popover on a mouse and a bottom sheet on a phone. */
+  .tc-sheet-backdrop {
+    @apply fixed inset-0 z-[100] bg-black/40 backdrop-blur-sm;
+  }
+  .tc-sheet {
+    @apply fixed inset-x-0 bottom-0 z-[100] max-h-[85vh] overflow-y-auto rounded-t-xl
+           border-t border-outline-variant bg-surface-container-lowest px-4 pt-2;
+    padding-bottom: calc(1rem + env(safe-area-inset-bottom));
+  }
+  .tc-sheet-handle {
+    @apply mx-auto mb-3 h-1 w-10 rounded-full bg-outline-variant;
+  }
+
+  /* ── Training agenda list ─────────────────────── */
+  /* Badges on a session card share a ~200px column with the title, beside the date rail,
+     so they tighten on a phone rather than taking a line each. */
+  .tc-badges {
+    @apply flex flex-wrap items-center gap-1.5;
+  }
+  .tc-badges > span {
+    @apply px-2 py-0.5 text-[12px] sm:px-3 sm:py-1 sm:text-sm;
+  }
+
+  .tc-month-heading {
+    @apply flex flex-wrap items-baseline gap-x-3 gap-y-1 border-b border-outline-variant/60 pb-2;
+  }
+  .tc-rail {
+    @apply flex w-12 shrink-0 flex-col items-center justify-center self-stretch rounded-sm border-l-[3px] py-1;
+  }
+  .tc-rail-day {
+    @apply text-2xl font-bold leading-none tabular-nums text-on-surface;
+  }
+  .tc-rail-weekday {
+    @apply mt-1 text-[11px] font-semibold text-on-surface-variant;
+  }
 }
 
 /* ────────────────────────────────────────────────
@@ -315,5 +406,275 @@
   }
   .scrollbar-hide::-webkit-scrollbar {
     display: none;
+  }
+}
+/* ════════════════════════════════════════════════
+ * FULLCALENDAR
+ * ------------------------------------------------
+ * Plain CSS, outside every @layer, on purpose: FullCalendar's own class names appear in no
+ * file Tailwind scans, so an @layer rule keyed on .fc-* would be purged straight back out of
+ * the build. Content outside the layers is passed through untouched.
+ * ════════════════════════════════════════════════ */
+
+.fc {
+  --fc-border-color: theme('colors.outline-variant');
+  --fc-page-bg-color: theme('colors.surface-container-lowest');
+  --fc-neutral-bg-color: theme('colors.surface-container-low');
+  --fc-today-bg-color: theme('colors.surface-container');
+  --fc-now-indicator-color: theme('colors.danger');
+  --fc-list-event-hover-bg-color: theme('colors.surface-container');
+  font-family: theme('fontFamily.body-md');
+  color: theme('colors.on-surface');
+}
+
+/* ── Toolbar ──────────────────────────────────── */
+.fc .fc-toolbar.fc-header-toolbar {
+  margin-bottom: 1rem;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.fc .fc-toolbar.fc-footer-toolbar {
+  margin-top: 1rem;
+}
+.fc .fc-toolbar-title {
+  font-family: theme('fontFamily.heading');
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: theme('colors.on-surface');
+}
+
+.fc .fc-button,
+.fc .fc-button-primary {
+  background-color: theme('colors.surface-container-lowest');
+  border: 1px solid theme('colors.outline-variant');
+  border-radius: theme('borderRadius.sm');
+  color: theme('colors.on-surface-variant');
+  font-family: theme('fontFamily.body-md');
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  min-height: 40px;
+  padding: 0.5rem 0.85rem;
+  box-shadow: none;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+.fc .fc-button-primary:not(:disabled):hover {
+  background-color: theme('colors.surface-container');
+  border-color: theme('colors.outline-variant');
+  color: theme('colors.on-surface');
+}
+.fc .fc-button-primary:not(:disabled).fc-button-active,
+.fc .fc-button-primary:not(:disabled):active {
+  background-color: theme('colors.primary-container');
+  border-color: theme('colors.primary-container');
+  color: theme('colors.on-primary-container');
+  box-shadow: none;
+}
+.fc .fc-button-primary:focus,
+.fc .fc-button-primary:focus-visible {
+  box-shadow: none;
+  outline: 2px solid theme('colors.on-surface');
+  outline-offset: 2px;
+}
+.fc .fc-button-primary:disabled {
+  background-color: theme('colors.surface-container-lowest');
+  border-color: theme('colors.outline-variant');
+  color: theme('colors.on-surface-variant');
+  opacity: 0.4;
+}
+.fc .fc-button-group > .fc-button:not(:first-child) {
+  margin-left: -1px;
+}
+
+/*
+ * Real chevrons. FullCalendar's own arrows come from an icon font embedded as a data: URI,
+ * which font-src blocks; Material Symbols is already loaded from fonts.gstatic.com, which it
+ * allows. The button text is emptied in JS and the glyph comes from here.
+ */
+.fc .fc-prev-button,
+.fc .fc-next-button {
+  width: 40px;
+  padding: 0;
+  font-size: 0;
+}
+.fc .fc-prev-button::before,
+.fc .fc-next-button::before {
+  font-family: 'Material Symbols Outlined';
+  font-size: 22px;
+  font-weight: normal;
+  line-height: 1;
+  content: 'chevron_left';
+}
+.fc .fc-next-button::before {
+  content: 'chevron_right';
+}
+
+/* ── Grid ─────────────────────────────────────── */
+.fc .fc-scrollgrid {
+  border-radius: theme('borderRadius.sm');
+  overflow: hidden;
+}
+.fc .fc-col-header-cell {
+  background-color: theme('colors.surface-container-low');
+  padding: 0.5rem 0;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: theme('colors.on-surface-variant');
+}
+.fc .fc-col-header-cell-cushion {
+  padding: 0;
+  text-decoration: none;
+}
+.fc .fc-daygrid-day-frame {
+  min-height: 5.5rem;
+}
+.fc .fc-daygrid-day-number {
+  padding: 6px 8px;
+  font-size: 13px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: theme('colors.on-surface-variant');
+  text-decoration: none;
+}
+.fc .fc-day-other .fc-daygrid-day-number {
+  opacity: 0.4;
+}
+.fc .fc-day-today .fc-daygrid-day-number {
+  min-width: 26px;
+  margin: 4px;
+  padding: 4px 0;
+  border-radius: theme('borderRadius.full');
+  background-color: theme('colors.primary-container');
+  color: theme('colors.on-primary-container');
+  text-align: center;
+}
+
+/*
+ * Tapping a day on a phone selects it rather than creating on it, and the day's sessions
+ * render below the grid. The state rides on an attribute rather than a class so it can never
+ * be purged.
+ */
+.fc .fc-daygrid-day[data-tc-selected] {
+  background-color: theme('colors.secondary-container');
+}
+/* Today keeps its filled pill when it is also the selected day; overriding the colour here
+ * would put near-black text on the near-black pill. */
+.fc .fc-daygrid-day[data-tc-selected]:not(.fc-day-today) .fc-daygrid-day-number {
+  color: theme('colors.on-surface');
+}
+
+/* ── Events ───────────────────────────────────── */
+/*
+ * The chip renderer paints its own tint and stripe, so FullCalendar's host element gets out
+ * of the way. !important is needed because the library writes those two properties inline.
+ */
+.fc .fc-daygrid-event,
+.fc .fc-timegrid-event {
+  background-color: transparent !important;
+  border-color: transparent !important;
+  border: 0;
+  box-shadow: none;
+}
+.fc .fc-daygrid-event-harness {
+  margin-bottom: 2px;
+}
+.fc .fc-event {
+  box-shadow: none;
+}
+.fc .fc-event:focus-visible {
+  outline: 2px solid theme('colors.on-surface');
+  outline-offset: 1px;
+}
+.fc .fc-event-main {
+  color: inherit;
+  padding: 0;
+}
+.fc .fc-daygrid-more-link {
+  padding: 0 4px;
+  font-size: 11px;
+  font-weight: 600;
+  color: theme('colors.on-surface-variant');
+}
+
+/* ── Time grid ────────────────────────────────── */
+.fc .fc-timegrid-slot {
+  height: 2.5rem;
+}
+.fc .fc-timegrid-slot-label-cushion,
+.fc .fc-timegrid-axis-cushion {
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: theme('colors.on-surface-variant');
+}
+.fc .fc-timegrid-now-indicator-arrow {
+  display: none;
+}
+
+/* ── List view ────────────────────────────────── */
+.fc .fc-list {
+  border-color: theme('colors.outline-variant');
+  border-radius: theme('borderRadius.sm');
+}
+.fc .fc-list-day-cushion {
+  background-color: theme('colors.surface-container-low');
+  font-family: theme('fontFamily.heading');
+  font-size: 13px;
+  font-weight: 700;
+  color: theme('colors.on-surface');
+}
+.fc .fc-list-event-time {
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  color: theme('colors.on-surface-variant');
+}
+.fc .fc-list-event-title a {
+  font-weight: 600;
+  color: theme('colors.on-surface');
+  text-decoration: none;
+}
+.fc .fc-list-empty {
+  background-color: transparent;
+  color: theme('colors.on-surface-variant');
+}
+
+/* ── Phones ───────────────────────────────────── */
+@media (max-width: 767px) {
+  .fc .fc-toolbar.fc-header-toolbar {
+    margin-bottom: 0.75rem;
+  }
+  .fc .fc-toolbar-title {
+    font-size: 1.0625rem;
+  }
+  .fc .fc-button,
+  .fc .fc-button-primary {
+    min-height: 36px;
+    padding: 0.4rem 0.6rem;
+    font-size: 12px;
+  }
+  .fc .fc-col-header-cell {
+    padding: 0.375rem 0;
+    font-size: 11px;
+  }
+  /* Dots, not chips: the row only has to hold a date and its load. */
+  .fc .fc-daygrid-day-frame {
+    min-height: 3rem;
+  }
+  .fc .fc-daygrid-day-number {
+    padding: 4px;
+    font-size: 12px;
+  }
+  .fc .fc-daygrid-day-events {
+    min-height: 0;
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width: 768px) {
+  .fc .fc-toolbar-title {
+    font-size: 1.5rem;
   }
 }

--- a/src/main/resources/frontend/tailwind.config.js
+++ b/src/main/resources/frontend/tailwind.config.js
@@ -1,6 +1,8 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ['../templates/**/*.html'],
+  // Scripts are scanned too: the calendar builds its chips and day agenda in JS, and a
+  // class name that appears only there would otherwise never be emitted into output.css.
+  content: ['../templates/**/*.html', '../static/js/**/*.js'],
   darkMode: "class",
   future: {
     hoverOnlyWhenSupported: true,

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -103,6 +103,20 @@ document.addEventListener('click', function(event) {
         return;
     }
 
+    // 2b. Generic show/hide toggle: a button carrying data-toggle-target="#id" flips the
+    // `hidden` class on that element. Used by the collapsed filter panel on the training
+    // agenda, where a responsive `hidden md:flex` keeps the desktop layout untouched.
+    const toggleBtn = event.target.closest('.js-toggle');
+    if (toggleBtn) {
+        event.preventDefault();
+        const target = document.querySelector(toggleBtn.dataset.toggleTarget);
+        if (target) {
+            target.classList.toggle('hidden');
+            toggleBtn.setAttribute('aria-expanded', String(!target.classList.contains('hidden')));
+        }
+        return;
+    }
+
     // 3. 3-dot menu toggle handler
     const menuBtn = event.target.closest('.js-menu-btn');
     if (menuBtn) {

--- a/src/main/resources/static/js/training-calendar.js
+++ b/src/main/resources/static/js/training-calendar.js
@@ -1,8 +1,21 @@
 /**
  * The FullCalendar training view.
  *
- * Inline scripts are impossible under this CSP, so all wiring lives here: the JSON feed,
- * click-to-create with a popover, and drag/resize writing through to Google Calendar.
+ * Inline scripts are impossible under this CSP, so all wiring lives here: the JSON feed, the
+ * chip renderer, click-to-create, and drag/resize writing through to Google Calendar.
+ *
+ * The page is two different things either side of 768px:
+ *
+ *   Pointer  — month, week and list views. Dragging a slot opens an anchored quick-create
+ *              card; dragging or resizing a session reschedules it.
+ *   Touch    — a month grid of load dots with the selected day's sessions listed underneath,
+ *              and a floating + that creates on that day. Tap reads, + creates: nothing is
+ *              overloaded, so no long-press is needed, and drag-to-reschedule stays off where
+ *              it would only ever fire by accident.
+ *
+ * Everything responsive is driven by the media query below and re-applied on `change`, so
+ * rotating a phone switches the page over instead of leaving whichever layout happened to
+ * be right when the script first ran.
  */
 (function () {
     'use strict';
@@ -11,15 +24,30 @@
     if (!host || typeof FullCalendar === 'undefined') return;
 
     const popover = document.getElementById('quickCreatePopover');
+    const sheet = document.getElementById('quickCreateSheet');
+    const sheetBody = document.getElementById('quickCreateSheetBody');
+    const backdrop = document.getElementById('quickCreateBackdrop');
+    const fab = document.getElementById('quickCreateFab');
     const errorBox = document.getElementById('calendarError');
 
-    /** CSRF for fetch, the same lookup choreography-builder.js uses for its reorder POSTs. */
-    function csrfHeaders() {
-        const token = document.querySelector('meta[name="_csrf"]');
-        const header = document.querySelector('meta[name="_csrf_header"]');
-        const headers = { 'Content-Type': 'application/x-www-form-urlencoded' };
-        if (token && header) headers[header.getAttribute('content')] = token.getAttribute('content');
-        return headers;
+    const agendaTitle = document.getElementById('dayAgendaTitle');
+    const agendaTotal = document.getElementById('dayAgendaTotal');
+    const agendaList = document.getElementById('dayAgendaList');
+    const agendaTemplate = document.getElementById('dayAgendaItemTemplate');
+
+    const narrow = window.matchMedia('(max-width: 767px)');
+
+    /** The day whose sessions the agenda panel is showing, as 'YYYY-MM-DD'. */
+    let selectedKey = dateKey(new Date());
+    let repaintHandle = null;
+
+    /** Evening default for the floating +, matching the server's own quick-create default. */
+    const DEFAULT_HOUR = 18;
+
+    // ── Formatting ──────────────────────────────────────────────────────────
+
+    function pad(n) {
+        return String(n).padStart(2, '0');
     }
 
     /**
@@ -28,9 +56,37 @@
      * shift every session by the zone offset.
      */
     function toLocalIso(date) {
-        const pad = function (n) { return String(n).padStart(2, '0'); };
-        return date.getFullYear() + '-' + pad(date.getMonth() + 1) + '-' + pad(date.getDate()) +
-            'T' + pad(date.getHours()) + ':' + pad(date.getMinutes()) + ':00';
+        return dateKey(date) + 'T' + pad(date.getHours()) + ':' + pad(date.getMinutes()) + ':00';
+    }
+
+    function dateKey(date) {
+        return date.getFullYear() + '-' + pad(date.getMonth() + 1) + '-' + pad(date.getDate());
+    }
+
+    function hhmm(date) {
+        return pad(date.getHours()) + ':' + pad(date.getMinutes());
+    }
+
+    /** "9h 30m", "45m", "3h" — whichever parts are non-zero. */
+    function durationLabel(minutes) {
+        const hours = Math.floor(minutes / 60);
+        const rest = minutes % 60;
+        if (!hours) return rest + 'm';
+        if (!rest) return hours + 'h';
+        return hours + 'h ' + rest + 'm';
+    }
+
+    function minutesBetween(start, end) {
+        return Math.max(0, Math.round((end - start) / 60000));
+    }
+
+    /** CSRF for fetch, the same lookup choreography-builder.js uses for its reorder POSTs. */
+    function csrfHeaders() {
+        const token = document.querySelector('meta[name="_csrf"]');
+        const header = document.querySelector('meta[name="_csrf_header"]');
+        const headers = { 'Content-Type': 'application/x-www-form-urlencoded' };
+        if (token && header) headers[header.getAttribute('content')] = token.getAttribute('content');
+        return headers;
     }
 
     function showError(message) {
@@ -43,46 +99,82 @@
         if (errorBox) errorBox.classList.add('hidden');
     }
 
-    function hidePopover() {
-        if (popover) {
-            popover.classList.add('hidden');
-            popover.innerHTML = '';
+    // ── Chips ───────────────────────────────────────────────────────────────
+
+    /**
+     * A session chip: a solid stripe in the status colour, that colour at 10% behind it, and
+     * the detail that fits. The feed sends the tint as backgroundColor and the solid colour
+     * as borderColor; the stylesheet clears FullCalendar's own fill so only this shows.
+     *
+     * List views keep FullCalendar's own row rendering, which the stylesheet themes instead.
+     */
+    function renderChip(arg) {
+        if (arg.view.type.indexOf('list') === 0) return true;
+
+        const props = arg.event.extendedProps || {};
+        const chip = document.createElement('div');
+        chip.className = 'tc-chip' + (props.status === 'cancelled' ? ' tc-chip-struck' : '');
+        chip.style.backgroundColor = arg.event.backgroundColor || 'transparent';
+        chip.style.borderLeftColor = arg.event.borderColor || 'transparent';
+
+        const time = document.createElement('span');
+        time.className = 'tc-chip-time';
+        time.textContent = arg.timeText || (arg.event.start ? hhmm(arg.event.start) : '');
+        if (props.repeating) {
+            const repeat = document.createElement('span');
+            repeat.className = 'material-symbols-outlined align-middle text-[12px] ml-1';
+            repeat.textContent = 'repeat';
+            time.appendChild(repeat);
         }
+        chip.appendChild(time);
+
+        const title = document.createElement('span');
+        title.className = 'tc-chip-title';
+        title.textContent = arg.event.title;
+        chip.appendChild(title);
+
+        // The style breakdown only earns its line where there is vertical room for it; a
+        // month cell has to hold several chips.
+        if (props.styles && props.styles.length && arg.view.type.indexOf('timeGrid') === 0) {
+            const styles = document.createElement('span');
+            styles.className = 'tc-chip-styles';
+            styles.textContent = props.styles.join(' · ');
+            chip.appendChild(styles);
+        }
+
+        return { domNodes: [chip] };
     }
 
-    const isNarrow = window.matchMedia('(max-width: 768px)').matches;
+    // ── Calendar ────────────────────────────────────────────────────────────
+
+    function toolbarFor(isNarrow) {
+        return isNarrow
+            // No view switcher on a phone: week and list views are unreadable at 360px, and
+            // the month grid plus the agenda panel below it already covers both jobs.
+            ? { left: 'prev,next', center: 'title', right: 'today' }
+            : { left: 'prev,next today', center: 'title', right: 'dayGridMonth,timeGridWeek,listWeek' };
+    }
 
     const calendar = new FullCalendar.Calendar(host, {
-        initialView: isNarrow ? 'listWeek' : 'dayGridMonth',
+        initialView: 'dayGridMonth',
         timeZone: 'local',
         firstDay: 1,
         height: 'auto',
         nowIndicator: true,
-        selectable: true,
-        editable: true,
-        // One row of controls does not fit a phone: the title ends up wrapping across
-        // three lines. Drop the view switcher to its own row there instead.
-        headerToolbar: isNarrow
-            ? { left: 'prev,next', center: 'title', right: 'today' }
-            : { left: 'prev,next today', center: 'title', right: 'dayGridMonth,timeGridWeek,listWeek' },
-        footerToolbar: isNarrow
-            ? { center: 'dayGridMonth,timeGridWeek,listWeek' }
-            : false,
-        titleFormat: isNarrow
-            ? { month: 'short', day: 'numeric' }
-            : { year: 'numeric', month: 'long' },
-        // FullCalendar's own chevrons come from an icon font embedded as a data: URI, which
-        // font-src blocks. Use text arrows in the app's font rather than widening the CSP
-        // for decoration -- otherwise prev/next render as empty boxes.
+        selectable: !narrow.matches,
+        editable: !narrow.matches,
+        eventDisplay: narrow.matches ? 'none' : 'auto',
+        headerToolbar: toolbarFor(narrow.matches),
+        titleFormat: { year: 'numeric', month: 'long' },
+        eventTimeFormat: { hour: '2-digit', minute: '2-digit', hour12: false },
+        // Emptied on purpose: the stylesheet draws real chevrons with Material Symbols, which
+        // font-src allows, where FullCalendar's own icon font is a blocked data: URI.
         buttonIcons: false,
-        buttonText: {
-            today: 'Today',
-            month: 'Month',
-            week: 'Week',
-            list: 'List',
-            prev: '\u2190',
-            next: '\u2192'
+        buttonText: { today: 'Today', month: 'Month', week: 'Week', list: 'List', prev: '', next: '' },
+        views: {
+            dayGridMonth: { dayMaxEvents: 2 }
         },
+        eventContent: renderChip,
 
         events: function (fetchInfo, success, failure) {
             const url = '/api/training-events/calendar?start=' +
@@ -102,25 +194,38 @@
         // Let the browser follow the event's own url instead of FullCalendar's handling,
         // so a session opens the app's detail page.
         eventClick: function (info) {
-            hidePopover();
+            hideQuickCreate();
             if (info.event.url) {
                 info.jsEvent.preventDefault();
                 window.location.href = info.event.url;
             }
         },
 
-        select: function (info) {
+        // Touch: tapping a day reads it. Creation is the floating +, so a mis-tap costs
+        // nothing and the create form never appears without being asked for.
+        dateClick: function (info) {
+            if (!narrow.matches) return;
             clearError();
-            openQuickCreate(info);
+            selectedKey = info.dateStr.slice(0, 10);
+            paint();
         },
 
-        eventDrop: function (info) {
-            persistMove(info);
+        // Pointer: dragging a range creates on it, as before.
+        select: function (info) {
+            if (narrow.matches) return;
+            clearError();
+            openQuickCreate(info.start, info.end, info.jsEvent);
         },
 
-        eventResize: function (info) {
-            persistMove(info);
-        }
+        eventDrop: persistMove,
+        eventResize: persistMove,
+
+        datesSet: function (info) {
+            if (narrow.matches) keepSelectionInView(info.view);
+            schedulePaint();
+        },
+
+        eventsSet: schedulePaint
     });
 
     /** Writes a drag or resize through the reschedule endpoint, reverting if it is refused. */
@@ -145,10 +250,161 @@
         });
     }
 
-    function openQuickCreate(info) {
-        if (!popover) return;
-        const url = '/training-events/quick-create?start=' + encodeURIComponent(toLocalIso(info.start)) +
-            '&end=' + encodeURIComponent(toLocalIso(info.end));
+    // ── Touch layout: day dots and the selected-day agenda ──────────────────
+
+    /** Navigating to another month would otherwise leave the agenda on a day that is gone. */
+    function keepSelectionInView(view) {
+        const first = dateKey(view.currentStart);
+        const past = dateKey(view.currentEnd);
+        if (selectedKey >= first && selectedKey < past) return;
+        const today = dateKey(new Date());
+        selectedKey = (today >= first && today < past) ? today : first;
+    }
+
+    function eventsByDay() {
+        const byDay = {};
+        calendar.getEvents().forEach(function (event) {
+            if (!event.start) return;
+            const key = dateKey(event.start);
+            (byDay[key] = byDay[key] || []).push(event);
+        });
+        Object.keys(byDay).forEach(function (key) {
+            byDay[key].sort(function (a, b) { return a.start - b.start; });
+        });
+        return byDay;
+    }
+
+    /** FullCalendar rebuilds its cells on every render, so repaint after one rather than during. */
+    function schedulePaint() {
+        if (repaintHandle) return;
+        repaintHandle = window.requestAnimationFrame(function () {
+            repaintHandle = null;
+            paint();
+        });
+    }
+
+    function paint() {
+        clearDayDecorations();
+        if (!narrow.matches) return;
+
+        const byDay = eventsByDay();
+
+        host.querySelectorAll('.fc-daygrid-day').forEach(function (cell) {
+            const key = cell.getAttribute('data-date');
+            if (key === selectedKey) cell.setAttribute('data-tc-selected', '');
+
+            const events = byDay[key];
+            const slot = cell.querySelector('.fc-daygrid-day-events');
+            if (!events || !slot) return;
+
+            const dots = document.createElement('div');
+            dots.className = 'tc-daydots';
+            events.slice(0, 4).forEach(function (event) {
+                const dot = document.createElement('span');
+                dot.className = 'tc-daydot';
+                dot.style.backgroundColor = event.borderColor || 'currentColor';
+                dots.appendChild(dot);
+            });
+            slot.appendChild(dots);
+        });
+
+        renderDayAgenda(byDay[selectedKey] || []);
+    }
+
+    function clearDayDecorations() {
+        host.querySelectorAll('.tc-daydots').forEach(function (node) { node.remove(); });
+        host.querySelectorAll('[data-tc-selected]').forEach(function (node) {
+            node.removeAttribute('data-tc-selected');
+        });
+    }
+
+    function renderDayAgenda(events) {
+        if (!agendaList || !agendaTemplate) return;
+
+        if (agendaTitle) {
+            agendaTitle.textContent = new Date(selectedKey + 'T00:00')
+                .toLocaleDateString(undefined, { weekday: 'long', day: 'numeric', month: 'long' });
+        }
+        agendaList.textContent = '';
+
+        if (!events.length) {
+            if (agendaTotal) agendaTotal.textContent = '';
+            const empty = document.createElement('p');
+            empty.className = 'tc-agenda-empty';
+            empty.textContent = 'Nothing scheduled. Tap + to add a session.';
+            agendaList.appendChild(empty);
+            return;
+        }
+
+        if (agendaTotal) {
+            const total = events.reduce(function (sum, event) {
+                return sum + (event.end ? minutesBetween(event.start, event.end) : 0);
+            }, 0);
+            agendaTotal.textContent = events.length + (events.length === 1 ? ' session · ' : ' sessions · ') +
+                durationLabel(total);
+        }
+
+        events.forEach(function (event) {
+            agendaList.appendChild(agendaRow(event));
+        });
+    }
+
+    function agendaRow(event) {
+        const props = event.extendedProps || {};
+        const row = agendaTemplate.content.firstElementChild.cloneNode(true);
+
+        row.setAttribute('href', event.url || '#');
+        row.style.backgroundColor = event.backgroundColor || '';
+        row.style.borderLeftColor = event.borderColor || '';
+
+        row.querySelector('[data-agenda-start]').textContent = hhmm(event.start);
+        row.querySelector('[data-agenda-end]').textContent = event.end ? hhmm(event.end) : '';
+
+        const title = row.querySelector('[data-agenda-title]');
+        title.textContent = event.title;
+        if (props.status === 'cancelled') title.classList.add('line-through', 'opacity-70');
+
+        const meta = row.querySelector('[data-agenda-meta]');
+        const parts = [];
+        if (props.statusLabel) parts.push(props.statusLabel);
+        if (event.end) parts.push(durationLabel(minutesBetween(event.start, event.end)));
+        meta.textContent = parts.join(' · ');
+
+        const styles = row.querySelector('[data-agenda-styles]');
+        if (props.styles && props.styles.length) {
+            styles.textContent = props.styles.join(' · ');
+        } else {
+            styles.remove();
+        }
+
+        return row;
+    }
+
+    // ── Quick create ────────────────────────────────────────────────────────
+
+    /** The sheet on touch, the anchored card on a pointer. Both hold the same fragment. */
+    function quickCreateBody() {
+        return narrow.matches ? sheetBody : popover;
+    }
+
+    function hideQuickCreate() {
+        if (popover) {
+            popover.classList.add('hidden');
+            popover.textContent = '';
+        }
+        if (sheet) sheet.classList.add('hidden');
+        if (sheetBody) sheetBody.textContent = '';
+        if (backdrop) backdrop.classList.add('hidden');
+        document.body.classList.remove('overflow-hidden');
+        calendar.unselect();
+    }
+
+    function openQuickCreate(start, end, jsEvent) {
+        const body = quickCreateBody();
+        if (!body) return;
+
+        const url = '/training-events/quick-create?start=' + encodeURIComponent(toLocalIso(start)) +
+            '&end=' + encodeURIComponent(toLocalIso(end));
 
         fetch(url, { headers: { 'Accept': 'text/html' } })
             .then(function (r) {
@@ -156,11 +412,21 @@
                 return r.text();
             })
             .then(function (html) {
-                popover.innerHTML = html;
-                popover.classList.remove('hidden');
-                positionPopover(info.jsEvent);
-                wireQuickCreate();
-                const title = popover.querySelector('input[type="text"]');
+                body.innerHTML = html;
+
+                if (narrow.matches) {
+                    backdrop.classList.remove('hidden');
+                    sheet.classList.remove('hidden');
+                    sheet.scrollTop = 0;
+                    // The page behind a sheet should not scroll away underneath it.
+                    document.body.classList.add('overflow-hidden');
+                } else {
+                    popover.classList.remove('hidden');
+                    positionPopover(jsEvent);
+                }
+
+                wireQuickCreate(body);
+                const title = body.querySelector('input[type="text"]');
                 if (title) title.focus();
             })
             .catch(function (e) { showError(e.message); });
@@ -195,17 +461,14 @@
         popover.style.top = (clientTop - bounds.top) + 'px';
     }
 
-    function wireQuickCreate() {
-        const close = popover.querySelector('[data-close-quick-create]');
-        if (close) close.addEventListener('click', function () {
-            hidePopover();
-            calendar.unselect();
-        });
+    function wireQuickCreate(root) {
+        const close = root.querySelector('[data-close-quick-create]');
+        if (close) close.addEventListener('click', hideQuickCreate);
 
-        const repeat = popover.querySelector('select[name="repeat"]');
-        const untilRow = popover.querySelector('#quickRepeatUntilRow');
+        const repeat = root.querySelector('select[name="repeat"]');
+        const untilRow = root.querySelector('#quickRepeatUntilRow');
         const until = untilRow ? untilRow.querySelector('input[type="date"]') : null;
-        const date = popover.querySelector('input[name="date"]');
+        const date = root.querySelector('input[name="date"]');
 
         if (repeat && untilRow) {
             repeat.addEventListener('change', function () {
@@ -221,15 +484,54 @@
         }
     }
 
+    if (fab) {
+        fab.addEventListener('click', function () {
+            clearError();
+            const start = new Date(selectedKey + 'T' + pad(DEFAULT_HOUR) + ':00:00');
+            const end = new Date(start.getTime() + 3600000);
+            openQuickCreate(start, end, null);
+        });
+    }
+
+    if (backdrop) backdrop.addEventListener('click', hideQuickCreate);
+
     document.addEventListener('click', function (event) {
         if (!popover || popover.classList.contains('hidden')) return;
         if (popover.contains(event.target) || host.contains(event.target)) return;
-        hidePopover();
+        hideQuickCreate();
     });
 
     document.addEventListener('keydown', function (event) {
-        if (event.key === 'Escape') hidePopover();
+        if (event.key === 'Escape') hideQuickCreate();
     });
 
+    // ── Breakpoint ──────────────────────────────────────────────────────────
+
+    function applyBreakpoint() {
+        const isNarrow = narrow.matches;
+        calendar.batchRendering(function () {
+            calendar.setOption('headerToolbar', toolbarFor(isNarrow));
+            calendar.setOption('selectable', !isNarrow);
+            calendar.setOption('editable', !isNarrow);
+            calendar.setOption('eventDisplay', isNarrow ? 'none' : 'auto');
+            if (isNarrow && calendar.view.type !== 'dayGridMonth') {
+                calendar.changeView('dayGridMonth');
+            }
+        });
+        schedulePaint();
+    }
+
+    function onBreakpointChange() {
+        hideQuickCreate();
+        applyBreakpoint();
+    }
+
+    if (narrow.addEventListener) {
+        narrow.addEventListener('change', onBreakpointChange);
+    } else if (narrow.addListener) {
+        narrow.addListener(onBreakpointChange);
+    }
+
     calendar.render();
+    schedulePaint();
 })();

--- a/src/main/resources/templates/training-events/calendar.html
+++ b/src/main/resources/templates/training-events/calendar.html
@@ -7,49 +7,84 @@
     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
         <div class="page-header mb-0">
             <h1 class="page-title text-3xl">Training</h1>
-            <p class="page-subtitle">Click a slot to add a session, or drag one to move it.</p>
+            <p class="page-subtitle hidden md:block">Click a slot to add a session, or drag one to move it.</p>
+            <p class="page-subtitle md:hidden">Tap a day to read it. Tap + to add a session.</p>
         </div>
         <div class="flex items-center gap-2 shrink-0">
             <a href="/training-events" class="btn-outline">
                 <span class="material-symbols-outlined text-[20px]">list</span>
                 Agenda
             </a>
-            <a href="/training-events/new" class="btn-primary">
+            <!-- On a phone the floating + creates on the selected day, so this would be a second
+                 create button competing with it for a very narrow header. -->
+            <a href="/training-events/new" class="btn-primary hidden md:inline-flex">
                 <span class="material-symbols-outlined text-[20px]">add</span>
                 Add Session
             </a>
         </div>
     </div>
 
-    <!-- Legend; the same colours the API sends as hex -->
-    <div class="flex flex-wrap items-center gap-4 font-label-sm text-label-sm text-on-surface-variant">
-        <span class="flex items-center gap-2">
-            <span class="w-3 h-3 rounded-full inline-block bg-[#1e2524]"></span> Planned
-        </span>
-        <span class="flex items-center gap-2">
-            <span class="w-3 h-3 rounded-full inline-block bg-[#695d46]"></span> Needs confirmation
-        </span>
-        <span class="flex items-center gap-2">
-            <span class="w-3 h-3 rounded-full inline-block bg-[#2e5d51]"></span> Attended
-        </span>
-        <span class="flex items-center gap-2">
-            <span class="w-3 h-3 rounded-full inline-block bg-[#ba1a1a]"></span> Skipped
-        </span>
-        <span class="flex items-center gap-2">
-            <span class="w-3 h-3 rounded-full inline-block bg-[#737877]"></span> Cancelled
+    <!-- Legend, drawn from the same palette the JSON feed colours events with. -->
+    <div class="flex flex-wrap items-center gap-x-4 gap-y-2 font-label-sm text-label-sm text-on-surface-variant">
+        <span th:each="swatch : ${statusLegend}" class="flex items-center gap-2">
+            <span class="w-3 h-3 rounded-full inline-block shrink-0"
+                  th:style="'background-color:' + ${swatch.color}"></span>
+            <span th:text="${swatch.label}">Planned</span>
         </span>
     </div>
 
-    <div class="card p-4 md:p-6 relative">
+    <div class="card p-3 md:p-6 relative">
         <div id="trainingCalendar"></div>
 
-        <!-- Quick-create popover; positioned over the calendar by the script -->
+        <!-- Quick-create popover, positioned over the calendar by the script. Pointer only:
+             on a phone the same fragment is shown in the bottom sheet below. -->
         <div id="quickCreatePopover"
              class="hidden absolute z-50 w-80 max-w-[calc(100vw-3rem)] bg-surface-container-lowest
                     border border-border rounded-md shadow-ambient p-4"></div>
     </div>
 
+    <!-- Selected-day agenda. A month cell on a phone is too small to read a session in, so it
+         carries load dots and the detail lands here instead. -->
+    <div id="dayAgenda" class="md:hidden space-y-3">
+        <div class="tc-agenda-heading">
+            <h2 id="dayAgendaTitle" class="font-headline-md text-lg font-semibold text-on-surface">Today</h2>
+            <span id="dayAgendaTotal" class="text-[13px] tabular-nums text-on-surface-variant"></span>
+        </div>
+        <div id="dayAgendaList" class="space-y-2"></div>
+    </div>
+
+    <!-- One agenda row, cloned per session by the script, so its classes stay in a template. -->
+    <template id="dayAgendaItemTemplate">
+        <a class="tc-agenda-card" data-agenda-link>
+            <span class="tc-agenda-time">
+                <span class="block" data-agenda-start>18:00</span>
+                <span class="block text-on-surface-variant/70" data-agenda-end>20:00</span>
+            </span>
+            <span class="min-w-0 flex-1">
+                <span class="block truncate font-headline-md text-[15px] font-semibold text-on-surface"
+                      data-agenda-title>Session</span>
+                <span class="mt-0.5 block text-[13px] text-on-surface-variant" data-agenda-meta></span>
+                <span class="mt-1 block text-[12px] text-on-surface-variant" data-agenda-styles></span>
+            </span>
+            <span class="material-symbols-outlined shrink-0 text-[20px] text-outline">chevron_right</span>
+        </a>
+    </template>
+
     <p id="calendarError" class="hidden form-error"></p>
+
+    <button id="quickCreateFab" type="button" class="tc-fab md:hidden"
+            aria-label="Add a session on the selected day">
+        <span class="material-symbols-outlined text-[26px]">add</span>
+    </button>
+
+    <!-- Quick create as a bottom sheet on phones. `md:hidden` stays on both while they are
+         shown, so a resize past the breakpoint can never leave a sheet stranded on desktop. -->
+    <div id="quickCreateBackdrop" class="tc-sheet-backdrop hidden md:hidden"></div>
+    <div id="quickCreateSheet" class="tc-sheet hidden md:hidden"
+         role="dialog" aria-modal="true" aria-label="New session">
+        <div class="tc-sheet-handle"></div>
+        <div id="quickCreateSheetBody"></div>
+    </div>
 
     <!--
       Loaded from unpkg because script-src allows that origin and nothing else external.
@@ -61,9 +96,11 @@
 
 </section>
 
-<!-- Quick-create card, served as a fragment when a slot is chosen -->
+<!-- Quick-create card, served as a fragment when a slot or a day is chosen -->
 <div th:fragment="quickCreateCard" th:remove="tag">
-    <form id="quickCreateForm" th:object="${trainingEvent}" method="post" action="/training-events"
+    <!-- th:action, not a plain action: it is what makes Thymeleaf add Spring Security's CSRF
+         hidden field. Without it the POST is rejected with an unlogged 403. -->
+    <form id="quickCreateForm" th:object="${trainingEvent}" method="post" th:action="@{/training-events}"
           class="space-y-3">
         <div class="flex items-start justify-between gap-2">
             <h3 class="font-headline-md text-lg font-semibold text-on-surface">New session</h3>

--- a/src/main/resources/templates/training-events/list.html
+++ b/src/main/resources/templates/training-events/list.html
@@ -21,45 +21,60 @@
         </div>
     </div>
 
-    <!-- Filters -->
+    <!-- Filters. Search stays out where it can be reached; the three selects would take the
+         whole screen on a phone, so they fold behind a toggle there and sit inline above it. -->
     <div class="sticky top-[72px] bg-background z-40 -mx-6 px-6 py-3 border-b border-outline-variant/30">
         <form id="filterForm" th:hx-get="@{/training-events}" hx-target="#events-list" hx-swap="outerHTML"
               hx-trigger="submit, change from:select" hx-push-url="false"
-              class="flex flex-col sm:flex-row gap-3">
+              class="flex flex-col md:flex-row gap-3">
 
-            <input type="search" name="search" th:value="${search}" placeholder="Search sessions..."
-                   class="form-input flex-1"
-                   th:hx-get="@{/training-events}" hx-target="#events-list" hx-swap="outerHTML"
-                   hx-include="#filterForm" hx-trigger="keyup changed delay:300ms">
+            <div class="flex items-center gap-2 md:flex-1">
+                <input type="search" name="search" th:value="${search}" placeholder="Search sessions..."
+                       class="form-input flex-1"
+                       th:hx-get="@{/training-events}" hx-target="#events-list" hx-swap="outerHTML"
+                       hx-include="#filterForm" hx-trigger="keyup changed delay:300ms">
 
-            <select name="eventTypes" class="form-select sm:w-48"
-                    th:hx-get="@{/training-events}" hx-target="#events-list" hx-swap="outerHTML"
-                    hx-include="#filterForm">
-                <option value="">All types</option>
-                <option th:each="type : ${eventTypeOptions}" th:value="${type}" th:text="${type}"
-                        th:selected="${selectedEventTypes != null && selectedEventTypes.contains(type)}">TRAINING</option>
-            </select>
+                <button type="button" class="js-toggle btn-outline md:hidden shrink-0 relative"
+                        data-toggle-target="#filterFields" aria-label="Show filters">
+                    <span class="material-symbols-outlined text-[20px]">tune</span>
+                    <span th:if="${activeFilterCount != null && activeFilterCount > 0}"
+                          th:text="${activeFilterCount}"
+                          class="absolute -top-1 -right-1 min-w-[18px] h-[18px] px-1 rounded-full
+                                 bg-primary-container text-on-primary-container text-[11px] font-bold
+                                 flex items-center justify-center">1</span>
+                </button>
+            </div>
 
-            <select name="attendanceStatuses" class="form-select sm:w-48"
-                    th:hx-get="@{/training-events}" hx-target="#events-list" hx-swap="outerHTML"
-                    hx-include="#filterForm">
-                <option value="">All statuses</option>
-                <option th:each="status : ${attendanceStatusOptions}" th:value="${status}" th:text="${status}"
-                        th:selected="${selectedStatuses != null && selectedStatuses.contains(status)}">PLANNED</option>
-            </select>
+            <div id="filterFields" class="hidden md:flex flex-col md:flex-row gap-3">
+                <select name="eventTypes" class="form-select md:w-48"
+                        th:hx-get="@{/training-events}" hx-target="#events-list" hx-swap="outerHTML"
+                        hx-include="#filterForm">
+                    <option value="">All types</option>
+                    <option th:each="type : ${eventTypeOptions}" th:value="${type}" th:text="${type}"
+                            th:selected="${selectedEventTypes != null && selectedEventTypes.contains(type)}">TRAINING</option>
+                </select>
 
-            <select name="categoryIds" class="form-select sm:w-48"
-                    th:hx-get="@{/training-events}" hx-target="#events-list" hx-swap="outerHTML"
-                    hx-include="#filterForm">
-                <option value="">All styles</option>
-                <option th:each="category : ${danceCategories}" th:value="${category.id}" th:text="${category.name}"
-                        th:selected="${selectedCategoryIds != null && selectedCategoryIds.contains(category.id)}">Standard</option>
-            </select>
+                <select name="attendanceStatuses" class="form-select md:w-48"
+                        th:hx-get="@{/training-events}" hx-target="#events-list" hx-swap="outerHTML"
+                        hx-include="#filterForm">
+                    <option value="">All statuses</option>
+                    <option th:each="status : ${attendanceStatusOptions}" th:value="${status}" th:text="${status}"
+                            th:selected="${selectedStatuses != null && selectedStatuses.contains(status)}">PLANNED</option>
+                </select>
+
+                <select name="categoryIds" class="form-select md:w-48"
+                        th:hx-get="@{/training-events}" hx-target="#events-list" hx-swap="outerHTML"
+                        hx-include="#filterForm">
+                    <option value="">All styles</option>
+                    <option th:each="category : ${danceCategories}" th:value="${category.id}" th:text="${category.name}"
+                            th:selected="${selectedCategoryIds != null && selectedCategoryIds.contains(category.id)}">Standard</option>
+                </select>
+            </div>
         </form>
     </div>
 
     <!-- Agenda list (HTMX swap target) -->
-    <div th:fragment="eventsList" id="events-list" class="space-y-gutter">
+    <div th:fragment="eventsList" id="events-list" class="space-y-lg">
 
         <div th:if="${events == null || events.isEmpty()}" class="empty-state">
             <span class="material-symbols-outlined empty-state-icon">calendar_month</span>
@@ -68,73 +83,106 @@
             <a href="/training-events/new" class="btn-primary mt-4">Add Session</a>
         </div>
 
-        <div th:each="event : ${events}" class="card p-5 flex flex-col sm:flex-row sm:items-center gap-4">
+        <!-- A training log is read in months: how much was scheduled, how many hours it came to. -->
+        <div th:each="group : ${monthGroups}" class="space-y-gutter">
 
-            <!-- Date block -->
-            <div class="flex sm:flex-col items-center sm:items-center gap-2 sm:gap-0 sm:w-20 shrink-0">
-                <span class="font-display-lg text-2xl font-bold text-on-surface"
-                      th:text="${#temporals.format(event.startTime, 'd')}">10</span>
-                <span class="font-label-sm text-label-sm uppercase tracking-wider text-on-surface-variant"
-                      th:text="${#temporals.format(event.startTime, 'MMM yyyy')}">Sep 2026</span>
-            </div>
-
-            <!-- Details -->
-            <div class="flex-1 min-w-0">
-                <div class="flex flex-wrap items-center gap-2">
-                    <a th:href="@{/training-events/{id}(id=${event.id})}"
-                       class="font-headline-lg text-lg font-semibold text-on-surface hover:text-primary transition-colors truncate"
-                       th:text="${event.title}">Monday practice</a>
-
-                    <span class="badge-primary" th:text="${event.eventType}">TRAINING</span>
-
-                    <span th:each="segment : ${event.segments}" class="badge-secondary"
-                          th:text="${segment.danceCategory.name} + ' ' + ${segment.durationMinutes} + 'min'">Standard 60min</span>
-
-                    <span th:if="${event.isAwaitingConfirmation}"
-                          class="badge-accent">Needs confirmation</span>
-
-                    <span th:unless="${event.isAwaitingConfirmation}"
-                          th:classappend="${event.attendanceStatus.name() == 'ATTENDED' ? 'badge-success' :
-                                            event.attendanceStatus.name() == 'SKIPPED' ? 'badge-danger' :
-                                            event.attendanceStatus.name() == 'CANCELLED' ? 'badge-neutral' : 'badge-neutral'}"
-                          th:text="${event.attendanceStatus}">PLANNED</span>
-                </div>
-
-                <p class="font-body-md text-body-md text-on-surface-variant mt-1">
-                    <span th:text="${#temporals.format(event.startTime, 'EEEE, HH:mm')}">Thursday, 18:00</span>
-                    <span> – </span>
-                    <span th:text="${#temporals.format(event.endTime, 'HH:mm')}">20:00</span>
+            <div class="tc-month-heading">
+                <h2 class="font-headline-md text-xl font-semibold text-on-surface" th:text="${group.label}">September 2026</h2>
+                <p class="font-body-md text-[14px] text-on-surface-variant tabular-nums">
+                    <span th:text="${group.sessionLabel}">6 sessions</span>
                     <span class="text-outline"> · </span>
-                    <span th:text="${event.durationMinutes} + ' min'">120 min</span>
+                    <span th:text="${group.totalLabel}">9h 30m</span>
                 </p>
             </div>
 
-            <!-- Actions -->
-            <div class="flex items-center gap-2 shrink-0">
-                <!-- One-tap confirmation for a past session still marked PLANNED -->
-                <form th:if="${event.isAwaitingConfirmation}"
-                      th:hx-post="@{/training-events/{id}/attendance(id=${event.id})}"
-                      hx-target="#events-list" hx-swap="outerHTML">
-                    <input type="hidden" name="status" value="ATTENDED">
-                    <button type="submit" class="btn-primary">Attended</button>
-                </form>
-                <form th:if="${event.isAwaitingConfirmation}"
-                      th:hx-post="@{/training-events/{id}/attendance(id=${event.id})}"
-                      hx-target="#events-list" hx-swap="outerHTML">
-                    <input type="hidden" name="status" value="SKIPPED">
-                    <button type="submit" class="btn-outline">Skipped</button>
-                </form>
+            <div th:each="row : ${group.rows}" th:with="event=${row.event}"
+                 class="card p-4 sm:p-5 flex items-start gap-3 sm:gap-4">
 
-                <a th:href="@{/training-events/{id}/edit(id=${event.id})}" class="btn-icon" title="Edit">
-                    <span class="material-symbols-outlined text-[20px]">edit</span>
-                </a>
+                <!-- Date rail; the stripe and tint are the session's status. -->
+                <div class="tc-rail"
+                     th:style="'border-left-color:' + ${row.swatch.color} + ';background-color:' + ${row.swatch.tint}">
+                    <span class="tc-rail-day" th:text="${#temporals.format(event.startTime, 'd')}">10</span>
+                    <span class="tc-rail-weekday" th:text="${#temporals.format(event.startTime, 'EEE')}">Thu</span>
+                </div>
 
-                <form th:action="@{/training-events/{id}/delete(id=${event.id})}" method="post"
-                      data-confirm="Delete this training session? It will also be removed from your Google Calendar.">
-                    <button type="submit" class="btn-icon text-error" title="Delete">
-                        <span class="material-symbols-outlined text-[20px]">delete</span>
+                <div class="flex-1 min-w-0">
+                    <a th:href="@{/training-events/{id}(id=${event.id})}"
+                       class="block truncate font-headline-lg text-base sm:text-lg font-semibold text-on-surface
+                              hover:text-primary transition-colors"
+                       th:text="${event.title}">Monday practice</a>
+
+                    <p class="font-body-md text-[14px] sm:text-body-md text-on-surface-variant mt-0.5 tabular-nums">
+                        <span th:text="${#temporals.format(event.startTime, 'HH:mm')} + '–' + ${#temporals.format(event.endTime, 'HH:mm')}">18:00–20:00</span>
+                        <span class="text-outline"> · </span>
+                        <span th:text="${event.durationMinutes} + ' min'">120 min</span>
+                    </p>
+
+                    <div class="tc-badges mt-2">
+                        <span class="badge-primary" th:text="${event.eventType}">TRAINING</span>
+
+                        <span th:each="segment : ${event.segments}" class="badge-secondary"
+                              th:text="${segment.danceCategory.name} + ' ' + ${segment.durationMinutes} + 'min'">Standard 60min</span>
+
+                        <span th:if="${event.isAwaitingConfirmation}" class="badge-accent">Needs confirmation</span>
+
+                        <span th:unless="${event.isAwaitingConfirmation}"
+                              th:classappend="${event.attendanceStatus.name() == 'ATTENDED' ? 'badge-success' :
+                                                event.attendanceStatus.name() == 'SKIPPED' ? 'badge-danger' :
+                                                event.attendanceStatus.name() == 'CANCELLED' ? 'badge-neutral' : 'badge-neutral'}"
+                              th:text="${event.attendanceStatus}">PLANNED</span>
+                    </div>
+
+                    <!-- One-tap confirmation for a past session still marked PLANNED. It sits in
+                         the body rather than the action column so a phone is not asked to fit
+                         four 48px controls on one row. -->
+                    <div th:if="${event.isAwaitingConfirmation}" class="flex flex-wrap gap-2 mt-3">
+                        <form th:hx-post="@{/training-events/{id}/attendance(id=${event.id})}"
+                              hx-target="#events-list" hx-swap="outerHTML">
+                            <input type="hidden" name="status" value="ATTENDED">
+                            <button type="submit" class="btn-primary">Attended</button>
+                        </form>
+                        <form th:hx-post="@{/training-events/{id}/attendance(id=${event.id})}"
+                              hx-target="#events-list" hx-swap="outerHTML">
+                            <input type="hidden" name="status" value="SKIPPED">
+                            <button type="submit" class="btn-outline">Skipped</button>
+                        </form>
+                    </div>
+                </div>
+
+                <!-- Edit and delete: inline on a pointer, behind an overflow menu on a phone. -->
+                <div class="hidden md:flex items-center gap-2 shrink-0">
+                    <a th:href="@{/training-events/{id}/edit(id=${event.id})}" class="btn-icon" title="Edit">
+                        <span class="material-symbols-outlined text-[20px]">edit</span>
+                    </a>
+                    <form th:action="@{/training-events/{id}/delete(id=${event.id})}" method="post"
+                          data-confirm="Delete this training session? It will also be removed from your Google Calendar.">
+                        <button type="submit" class="btn-icon text-error" title="Delete">
+                            <span class="material-symbols-outlined text-[20px]">delete</span>
+                        </button>
+                    </form>
+                </div>
+
+                <div class="relative md:hidden shrink-0">
+                    <button type="button" class="js-menu-btn btn-icon" aria-label="More actions">
+                        <span class="material-symbols-outlined text-[20px]">more_vert</span>
                     </button>
-                </form>
+                    <div class="js-menu-dropdown hidden absolute right-0 top-full mt-1 w-44 z-30 py-1
+                                rounded-md border border-outline-variant bg-surface-container-lowest shadow-ambient">
+                        <a th:href="@{/training-events/{id}/edit(id=${event.id})}"
+                           class="flex items-center gap-2 px-3 py-2 font-body-md text-[15px] text-on-surface hover:bg-surface-container">
+                            <span class="material-symbols-outlined text-[18px]">edit</span>
+                            Edit
+                        </a>
+                        <form th:action="@{/training-events/{id}/delete(id=${event.id})}" method="post"
+                              data-confirm="Delete this training session? It will also be removed from your Google Calendar.">
+                            <button type="submit"
+                                    class="flex w-full items-center gap-2 px-3 py-2 font-body-md text-[15px] text-error hover:bg-surface-container">
+                                <span class="material-symbols-outlined text-[18px]">delete</span>
+                                Delete
+                            </button>
+                        </form>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/test/kotlin/com/jankowski/rafal/dancebook/controller/api/TrainingCalendarApiControllerTest.kt
+++ b/src/test/kotlin/com/jankowski/rafal/dancebook/controller/api/TrainingCalendarApiControllerTest.kt
@@ -82,12 +82,29 @@ class TrainingCalendarApiControllerTest {
                 )
             )
 
-        val colours = controller.calendarFeed("2026-01-01T00:00:00", "2027-01-01T00:00:00")
-            .map { it.backgroundColor }
+        val feed = controller.calendarFeed("2026-01-01T00:00:00", "2027-01-01T00:00:00")
 
-        assertEquals(5, colours.distinct().size)
+        assertEquals(5, feed.map { it.backgroundColor }.distinct().size)
+        assertEquals(5, feed.map { it.extendedProps.status }.distinct().size)
         // A past PLANNED session gets its own colour rather than looking merely planned.
-        assertTrue(colours[0] != colours[1])
+        assertTrue(feed[0].backgroundColor != feed[1].backgroundColor)
+        assertEquals("planned", feed[0].extendedProps.status)
+        assertEquals("unconfirmed", feed[1].extendedProps.status)
+    }
+
+    @Test
+    fun `should send the stripe colour solid and the fill tinted`() {
+        `when`(trainingEventService.findInRange(any(LocalDateTime::class.java), any(LocalDateTime::class.java)))
+            .thenReturn(listOf(event(AttendanceStatus.ATTENDED, LocalDateTime.now().minusDays(1))))
+
+        val chip = controller.calendarFeed("2026-01-01T00:00:00", "2027-01-01T00:00:00")[0]
+
+        // The chip is drawn as a solid stripe over a faint wash of the same colour, so the
+        // fill has to be the border colour plus an alpha rather than a second value.
+        assertEquals(chip.borderColor + "1a", chip.backgroundColor)
+        // Text sits on the tint, not on the solid colour, so it stays readable.
+        assertEquals("#1b1c1b", chip.textColor)
+        assertEquals("Attended", chip.extendedProps.statusLabel)
     }
 
     @Test

--- a/src/test/kotlin/com/jankowski/rafal/dancebook/controller/web/TrainingEventViewRenderingTest.kt
+++ b/src/test/kotlin/com/jankowski/rafal/dancebook/controller/web/TrainingEventViewRenderingTest.kt
@@ -1,0 +1,189 @@
+package com.jankowski.rafal.dancebook.controller.web
+
+import com.jankowski.rafal.dancebook.config.SecurityConfig
+import com.jankowski.rafal.dancebook.model.AttendanceStatus
+import com.jankowski.rafal.dancebook.model.DanceCategory
+import com.jankowski.rafal.dancebook.model.TrainingEvent
+import com.jankowski.rafal.dancebook.model.TrainingEventSegment
+import com.jankowski.rafal.dancebook.service.ActivityEventService
+import com.jankowski.rafal.dancebook.service.AppUserService
+import com.jankowski.rafal.dancebook.service.CustomListService
+import com.jankowski.rafal.dancebook.service.DanceCategoryService
+import com.jankowski.rafal.dancebook.service.SystemSettingService
+import com.jankowski.rafal.dancebook.service.TrainingEventService
+import com.jankowski.rafal.dancebook.service.TrainingSeriesService
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration
+import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientWebSecurityAutoConfiguration
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
+import org.springframework.context.annotation.Import
+import org.springframework.security.web.servlet.support.csrf.CsrfRequestDataValueProcessor
+import org.springframework.web.servlet.support.RequestDataValueProcessor
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.view
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * Renders the training templates for real.
+ *
+ * The unit tests above check what goes into the model; nothing there notices a template that
+ * asks the model for something it does not have. These do -- a bad expression fails the
+ * render, so every page and fragment the calendar and agenda rely on is exercised here.
+ */
+@WebMvcTest(
+    controllers = [TrainingEventWebController::class],
+    excludeAutoConfiguration = [
+        SecurityAutoConfiguration::class,
+        OAuth2ClientAutoConfiguration::class,
+        OAuth2ClientWebSecurityAutoConfiguration::class
+    ],
+    excludeFilters = [
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [SecurityConfig::class])
+    ]
+)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(TrainingEventViewRenderingTest.CsrfProcessorConfig::class)
+class TrainingEventViewRenderingTest {
+
+    /**
+     * Security's own filters are off here, but the processor that puts the CSRF hidden field
+     * into a `th:action` form is what the real app relies on, so it has to be present or a
+     * form missing its token would render identically to one that has it.
+     */
+    @TestConfiguration
+    class CsrfProcessorConfig {
+        @Bean
+        fun requestDataValueProcessor(): RequestDataValueProcessor = CsrfRequestDataValueProcessor()
+    }
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockBean private lateinit var trainingEventService: TrainingEventService
+    @MockBean private lateinit var trainingSeriesService: TrainingSeriesService
+    @MockBean private lateinit var danceCategoryService: DanceCategoryService
+
+    // Pulled in by NavbarAdvice, which supplies the layout's model on every page.
+    @MockBean private lateinit var customListService: CustomListService
+    @MockBean private lateinit var appUserService: AppUserService
+    @MockBean private lateinit var activityEventService: ActivityEventService
+    @MockBean private lateinit var systemSettingService: SystemSettingService
+
+    @Test
+    fun `should render the agenda with month headings and a status rail per session`() {
+        `when`(trainingEventService.findByCurrentUser(null, null, null, null))
+            .thenReturn(listOf(attendedSession(), awaitingSession()))
+        `when`(danceCategoryService.findAll()).thenReturn(emptyList())
+
+        mockMvc.perform(get("/training-events").with(csrf()))
+            .andExpect(status().isOk)
+            .andExpect(view().name("training-events/list"))
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("September 2026")))
+            // The rail's stripe is the session's own status colour, straight from the palette.
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("border-left-color:#2e5d51")))
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("border-left-color:#695d46")))
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("Needs confirmation")))
+            // Edit and delete fold behind an overflow menu on a phone.
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("js-menu-dropdown")))
+    }
+
+    @Test
+    fun `should render the agenda fragment on its own for an HTMX swap`() {
+        `when`(trainingEventService.findByCurrentUser(null, null, null, null))
+            .thenReturn(listOf(attendedSession()))
+
+        mockMvc.perform(get("/training-events").header("HX-Request", "true").with(csrf()))
+            .andExpect(status().isOk)
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("tc-month-heading")))
+    }
+
+    @Test
+    fun `should render the empty agenda when nothing is logged`() {
+        `when`(trainingEventService.findByCurrentUser(null, null, null, null)).thenReturn(emptyList())
+        `when`(danceCategoryService.findAll()).thenReturn(emptyList())
+
+        mockMvc.perform(get("/training-events").with(csrf()))
+            .andExpect(status().isOk)
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("No training sessions yet")))
+    }
+
+    @Test
+    fun `should render the calendar page with the legend drawn from the palette`() {
+        mockMvc.perform(get("/training-events/calendar").with(csrf()))
+            .andExpect(status().isOk)
+            .andExpect(view().name("training-events/calendar"))
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("Needs confirmation")))
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("background-color:#ba1a1a")))
+            // The mobile half of the page: the day agenda, its row template and the create button.
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("dayAgendaItemTemplate")))
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("quickCreateFab")))
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("quickCreateSheet")))
+    }
+
+    @Test
+    fun `should render the quick-create fragment the calendar fetches into its sheet`() {
+        mockMvc.perform(
+            get("/training-events/quick-create")
+                .param("start", "2026-09-14T18:00:00")
+                .param("end", "2026-09-14T19:00:00")
+        )
+            .andExpect(status().isOk)
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("quickCreateForm")))
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("Weekly on Monday")))
+            // The script wires the repeat control by these two hooks.
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("quickRepeatUntilRow")))
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("name=\"repeat\"")))
+    }
+
+    private fun attendedSession() = session(LocalDateTime.of(2026, 9, 14, 18, 0), AttendanceStatus.ATTENDED)
+        .apply {
+            segments.add(TrainingEventSegment().apply {
+                danceCategory = DanceCategory().apply { id = UUID.randomUUID(); name = "Standard" }
+                durationMinutes = 60
+                sortOrder = 0
+            })
+        }
+
+    /** Past and still PLANNED, so the agenda has to offer the one-tap confirmation buttons. */
+    private fun awaitingSession() = session(LocalDateTime.now().minusDays(3), AttendanceStatus.PLANNED)
+
+    private fun session(start: LocalDateTime, status: AttendanceStatus) = TrainingEvent().apply {
+        id = UUID.randomUUID()
+        title = "Monday practice"
+        startTime = start
+        endTime = start.plusHours(2)
+        attendanceStatus = status
+    }
+
+    /**
+     * The quick-create card posts a normal HTML form, so Spring Security wants a CSRF token in
+     * the body. Thymeleaf only adds that hidden field for `th:action`; with a plain `action`
+     * attribute the POST is rejected with a 403 that Spring Security does not log, which looks
+     * like a blank error page and a session that silently never got created.
+     */
+    @Test
+    fun `should carry a CSRF token in the quick-create form`() {
+        val html = mockMvc.perform(
+            get("/training-events/quick-create").with(csrf())
+                .param("start", "2026-09-14T18:00:00")
+                .param("end", "2026-09-14T19:00:00")
+        ).andReturn().response.contentAsString
+
+        assertTrue(html.contains("_csrf"), "quick-create form posts without a CSRF token: $html")
+    }
+}

--- a/src/test/kotlin/com/jankowski/rafal/dancebook/controller/web/TrainingEventWebControllerTest.kt
+++ b/src/test/kotlin/com/jankowski/rafal/dancebook/controller/web/TrainingEventWebControllerTest.kt
@@ -1,5 +1,6 @@
 package com.jankowski.rafal.dancebook.controller.web
 
+import com.jankowski.rafal.dancebook.controller.TrainingEventPalette
 import com.jankowski.rafal.dancebook.dto.TrainingEventRequest
 import com.jankowski.rafal.dancebook.model.AttendanceStatus
 import com.jankowski.rafal.dancebook.model.DanceCategory
@@ -269,5 +270,98 @@ class TrainingEventWebControllerTest {
         assertEquals("redirect:/training-events", viewName)
         verify(trainingEventService).delete(id)
         verify(trainingSeriesService, never()).deleteThisAndFollowing(id)
+    }
+
+    @Test
+    fun `should group the agenda by month with session counts and total hours`() {
+        val model = ConcurrentModel()
+        `when`(trainingEventService.findByCurrentUser(null, null, null, null)).thenReturn(
+            listOf(
+                session(LocalDateTime.of(2026, 9, 14, 18, 0), 120),
+                session(LocalDateTime.of(2026, 9, 17, 19, 0), 90),
+                session(LocalDateTime.of(2026, 10, 1, 18, 0), 60)
+            )
+        )
+        `when`(danceCategoryService.findAll()).thenReturn(emptyList())
+
+        controller.listTrainingEvents(model = model)
+
+        @Suppress("UNCHECKED_CAST")
+        val groups = model["monthGroups"] as List<TrainingMonthGroup>
+        assertEquals(2, groups.size)
+        assertEquals("September 2026", groups[0].label)
+        assertEquals(2, groups[0].sessionCount)
+        assertEquals("3h 30m", groups[0].totalLabel)
+        assertEquals("1h", groups[1].totalLabel)
+    }
+
+    @Test
+    fun `should carry a status swatch on every agenda row so the template never derives one`() {
+        val model = ConcurrentModel()
+        `when`(trainingEventService.findByCurrentUser(null, null, null, null)).thenReturn(
+            listOf(session(LocalDateTime.now().minusDays(2), 60))
+        )
+        `when`(danceCategoryService.findAll()).thenReturn(emptyList())
+
+        controller.listTrainingEvents(model = model)
+
+        @Suppress("UNCHECKED_CAST")
+        val groups = model["monthGroups"] as List<TrainingMonthGroup>
+        // A past session still marked PLANNED reads as needing confirmation, not as planned.
+        assertEquals("unconfirmed", groups[0].rows[0].swatch.key)
+    }
+
+    /**
+     * The fragment is the HTMX swap target for both the filters and the attendance buttons,
+     * so a path that only set `events` would swap in a list with no month headings at all.
+     */
+    @Test
+    fun `should group the agenda on the HTMX fragment branch too`() {
+        val model = ConcurrentModel()
+        `when`(trainingEventService.findByCurrentUser(null, null, null, null)).thenReturn(
+            listOf(session(LocalDateTime.of(2026, 9, 14, 18, 0), 120))
+        )
+
+        controller.listTrainingEvents(isHtmxRequest = true, model = model)
+
+        @Suppress("UNCHECKED_CAST")
+        val groups = model["monthGroups"] as List<TrainingMonthGroup>
+        assertEquals("September 2026", groups[0].label)
+    }
+
+    @Test
+    fun `should group the agenda after an attendance confirmation swaps the list back`() {
+        val model = ConcurrentModel()
+        val id = UUID.randomUUID()
+        `when`(trainingEventService.findByCurrentUser()).thenReturn(
+            listOf(session(LocalDateTime.of(2026, 9, 14, 18, 0), 120))
+        )
+
+        val viewName = controller.updateAttendance(id, AttendanceStatus.ATTENDED, true, model)
+
+        assertEquals("training-events/list :: eventsList", viewName)
+        @Suppress("UNCHECKED_CAST")
+        val groups = model["monthGroups"] as List<TrainingMonthGroup>
+        assertEquals(1, groups[0].sessionCount)
+    }
+
+    @Test
+    fun `should give the calendar page the same palette the feed colours events with`() {
+        val model = ConcurrentModel()
+
+        val viewName = controller.showCalendar(model)
+
+        assertEquals("training-events/calendar", viewName)
+        @Suppress("UNCHECKED_CAST")
+        val legend = model["statusLegend"] as List<TrainingEventPalette.Swatch>
+        assertEquals(5, legend.size)
+        assertEquals(legend.map { it.color }.distinct().size, legend.size)
+    }
+
+    private fun session(start: LocalDateTime, minutes: Long) = TrainingEvent().apply {
+        id = UUID.randomUUID()
+        title = "Monday practice"
+        startTime = start
+        endTime = start.plusMinutes(minutes)
     }
 }


### PR DESCRIPTION
## Why

Adding a session from the calendar was impossible on a phone. Below 768px the script opened `listWeek`, and **a list view has no selectable grid, so `select` never fired** — the only way in was the "Add Session" button that scrolls away with the header. Switching to the month view barely helped: on touch, `select` needs a ~1s long-press, and the quick-create popover positioned itself from the pointer's `clientX/clientY` inside a month grid taller than the viewport. The breakpoint was also read once at load and never listened to again, so rotating a phone left the wrong view and the wrong toolbar.

Separately, FullCalendar was completely unstyled — `grep -c "fc-" output.css` returned **0** — so its default chrome sat inside a Noble Harmony card unmediated, and the agenda list crowded four 48px controls onto one row at 390px.

## What changed

**The phone gets its own shape.** A month grid of load dots, because a cell that size cannot hold a readable chip, with the selected day's sessions listed underneath and a floating **+** that creates on that day through a bottom sheet. Tap reads, + creates — nothing is overloaded, so no long-press is needed. Drag-to-reschedule is off on touch, where it only ever fires by accident.

**Pointer behaviour is unchanged.** Drag a range to create, drag or resize to move.

**FullCalendar is themed**, and chips now render the time, title and dance-style breakdown the feed already sent in `extendedProps` and the script threw away. A chip is a solid status stripe over a 10% wash of the same colour instead of a solid dark block, so the feed sends the tint as `backgroundColor` and the solid colour as `borderColor`. All five values moved into `TrainingEventPalette`, shared with the legend on the page — which used to be a hand-kept second copy.

**The agenda list** is grouped by month with session counts and hours, its date rail carries the status colour, filters fold behind a toggle on a phone, and edit/delete move into an overflow menu.

## Bug fixed along the way

**Quick-create was posting without a CSRF token.** Its form was the only one of the 34 in the templates using a plain `action` rather than `th:action`, and Thymeleaf only injects the hidden field for the latter — so every save was rejected with a 403 that Spring Security does not log. A blank page and no session created, **on desktop as well as mobile**. This shipped with the calendar and is fixed here.

Two contrast defects also turned up while checking rendered pages in a browser: today's date pill went near-black on near-black when it was also the selected day, and `.badge-primary` pairs `#1b1c1b` text with a `#1e2524` pill — that one predates this change and affects three other templates too.

## Notes for review

- The `.fc-*` theming is **plain CSS outside every `@layer`**. Those class names appear in no file Tailwind scans, so an `@layer` rule keyed on them would be purged back out of the build. For the same reason the selected day is marked with a `data-` attribute rather than a class, and the content globs now cover `static/js`.
- Prev/next are real chevrons again. FullCalendar's own arrows come from an icon font embedded as a `data:` URI, which `font-src` blocks; Material Symbols is already loaded from `fonts.gstatic.com`, which it allows, so the glyph comes from CSS. **No CSP change.**
- Testing the CSRF fix needs a real `CsrfRequestDataValueProcessor` in the context — without one, a form with no token renders identically to one that has it, and the test passes while the app stays broken.

## Testing

- New `TrainingEventViewRenderingTest` renders every affected page and fragment for real. The existing unit tests only checked the model, so nothing caught a bad expression before.
- `TrainingEventWebControllerTest` covers month grouping on all three paths that render the `eventsList` fragment — full page, HTMX filter swap, attendance swap. Missing one leaves the swap target with no month headings.
- Drove the built output in Chrome at 390px against a stubbed feed: day dots, day selection, agenda totals, bottom sheet (backdrop, scroll lock, Escape), overflow menu, collapsed filters, zero horizontal overflow — plus chips and inline filters at 1920px. The breakpoint flip was exercised as a `setOption` sequence against a live FullCalendar instance, since the environment would not resize the window.
- Save-from-sheet confirmed working end to end by @AnielskieOczko after the CSRF fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)