### PR TITLE
Training calendar phase 3: a chronological timeline of training history

### DIFF
--- a/src/main/kotlin/com/jankowski/rafal/dancebook/controller/web/NavbarAdvice.kt
+++ b/src/main/kotlin/com/jankowski/rafal/dancebook/controller/web/NavbarAdvice.kt
@@ -61,6 +61,9 @@ class NavbarAdvice(
             path.startsWith("/lists") -> "lists"
             path.startsWith("/dance-figures") -> "dance-figures"
             path.startsWith("/choreographies") -> "choreographies"
+            // Ahead of the /training-events branch: the timeline is its own top-level nav entry,
+            // and `when` takes the first match.
+            path.startsWith("/training-events/timeline") -> "training-timeline"
             path.startsWith("/training-events") -> "training-events"
             path.startsWith("/dance-types") -> "dance-types"
             path.startsWith("/dance-categories") -> "dance-categories"

--- a/src/main/kotlin/com/jankowski/rafal/dancebook/controller/web/TrainingEventWebController.kt
+++ b/src/main/kotlin/com/jankowski/rafal/dancebook/controller/web/TrainingEventWebController.kt
@@ -3,6 +3,7 @@ package com.jankowski.rafal.dancebook.controller.web
 import com.jankowski.rafal.dancebook.dto.TrainingEventPalette
 import com.jankowski.rafal.dancebook.dto.TrainingEventRequest
 import com.jankowski.rafal.dancebook.dto.TrainingEventSegmentRequest
+import com.jankowski.rafal.dancebook.dto.groupByMonth
 import com.jankowski.rafal.dancebook.model.AttendanceStatus
 import com.jankowski.rafal.dancebook.model.TrainingEvent
 import com.jankowski.rafal.dancebook.model.TrainingEventType
@@ -27,8 +28,6 @@ import org.springframework.http.ResponseEntity
 import java.time.Duration
 import java.time.LocalDateTime
 import java.time.LocalTime
-import java.time.YearMonth
-import java.time.format.DateTimeFormatter
 import java.time.format.TextStyle
 import java.util.Locale
 import java.util.UUID
@@ -46,8 +45,6 @@ class TrainingEventWebController(
 
         /** Evening default for a day clicked in month view; most training is after work. */
         private const val DEFAULT_HOUR = 18
-
-        private val MONTH_LABEL: DateTimeFormatter = DateTimeFormatter.ofPattern("MMMM yyyy", Locale.ENGLISH)
     }
 
     @GetMapping
@@ -307,53 +304,9 @@ class TrainingEventWebController(
      * here rather than in the template because Thymeleaf can only compare a row against its
      * predecessor, which makes the totals awkward and the markup worse.
      */
-    private fun groupByMonth(events: List<TrainingEvent>): List<TrainingMonthGroup> =
-        events.groupBy { YearMonth.from(it.startTime) }
-            .map { (month, monthEvents) ->
-                TrainingMonthGroup(
-                    label = month.format(MONTH_LABEL),
-                    rows = monthEvents.map { TrainingEventRow(it, TrainingEventPalette.swatchFor(it)) },
-                    totalMinutes = monthEvents.sumOf { it.durationMinutes }
-                )
-            }
-
     private fun populateFormOptions(model: Model) {
         model.addAttribute("danceCategories", danceCategoryService.findAll())
         model.addAttribute("eventTypeOptions", TrainingEventType.entries.toTypedArray())
         model.addAttribute("attendanceStatusOptions", AttendanceStatus.entries.toTypedArray())
     }
-}
-
-/**
- * A session as the agenda draws it. The swatch travels with the event so the template never
- * has to re-derive a colour from a status, which is how the palette came to be duplicated.
- */
-data class TrainingEventRow(
-    val event: TrainingEvent,
-    val swatch: TrainingEventPalette.Swatch
-)
-
-/**
- * One month of the agenda, with the totals that make a training log worth grouping.
- */
-data class TrainingMonthGroup(
-    val label: String,
-    val rows: List<TrainingEventRow>,
-    val totalMinutes: Long
-) {
-    val sessionCount: Int get() = rows.size
-
-    val sessionLabel: String get() = if (sessionCount == 1) "1 session" else "$sessionCount sessions"
-
-    /** "9h 30m", "45m", "3h" -- whichever parts are non-zero. */
-    val totalLabel: String
-        get() {
-            val hours = totalMinutes / 60
-            val minutes = totalMinutes % 60
-            return when {
-                hours == 0L -> "${minutes}m"
-                minutes == 0L -> "${hours}h"
-                else -> "${hours}h ${minutes}m"
-            }
-        }
 }

--- a/src/main/kotlin/com/jankowski/rafal/dancebook/controller/web/TrainingTimelineWebController.kt
+++ b/src/main/kotlin/com/jankowski/rafal/dancebook/controller/web/TrainingTimelineWebController.kt
@@ -1,0 +1,49 @@
+package com.jankowski.rafal.dancebook.controller.web
+
+import com.jankowski.rafal.dancebook.service.TrainingTimelineService
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+
+/**
+ * The chronological training timeline.
+ *
+ * Its own controller, like the statistics page, rather than more weight on
+ * TrainingEventWebController.
+ *
+ * The route sits under /training-events so the calendar, agenda, stats and timeline stay one
+ * family of URLs, but NavbarAdvice.activeNav() gives it its own value: it is a top-level entry
+ * in the desktop navbar and must not light up the Training link instead of its own.
+ */
+@Controller
+@RequestMapping("/training-events/timeline")
+class TrainingTimelineWebController(
+    private val trainingTimelineService: TrainingTimelineService
+) {
+
+    @GetMapping
+    fun showTimeline(
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(required = false) lastMonth: String? = null,
+        @RequestHeader("HX-Request", required = false) isHtmxRequest: Boolean? = null,
+        model: Model
+    ): String {
+        // A negative page would page backwards off the end of the history.
+        val timeline = trainingTimelineService.timelineForCurrentUser(page.coerceAtLeast(0))
+
+        model.addAttribute("timeline", timeline)
+        // The month already on screen when this window was requested. The first heading is
+        // suppressed when it matches, so an appended window continues a month rather than
+        // repeating its heading halfway down the page.
+        model.addAttribute("continuedMonth", lastMonth)
+
+        if (isHtmxRequest != true) {
+            model.addAttribute("pageTitle", "Training timeline")
+        }
+
+        return if (isHtmxRequest == true) "training-events/timeline :: timelinePage" else "training-events/timeline"
+    }
+}

--- a/src/main/kotlin/com/jankowski/rafal/dancebook/dto/TrainingMonthGroup.kt
+++ b/src/main/kotlin/com/jankowski/rafal/dancebook/dto/TrainingMonthGroup.kt
@@ -1,0 +1,50 @@
+package com.jankowski.rafal.dancebook.dto
+
+import com.jankowski.rafal.dancebook.model.TrainingEvent
+import java.time.YearMonth
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+private val MONTH_LABEL: DateTimeFormatter = DateTimeFormatter.ofPattern("MMMM yyyy", Locale.ENGLISH)
+
+/**
+ * A session as a training page draws it. The swatch travels with the event so the template never
+ * has to re-derive a colour from a status, which is how the palette came to be duplicated.
+ */
+data class TrainingEventRow(
+    val event: TrainingEvent,
+    val swatch: TrainingEventPalette.Swatch
+)
+
+/**
+ * One month of training, with the totals that make a training log worth grouping.
+ */
+data class TrainingMonthGroup(
+    val label: String,
+    val rows: List<TrainingEventRow>,
+    val totalMinutes: Long
+) {
+    val sessionCount: Int get() = rows.size
+
+    val sessionLabel: String get() = if (sessionCount == 1) "1 session" else "$sessionCount sessions"
+
+    /** "9h 30m", "45m", "3h" -- whichever parts are non-zero. */
+    val totalLabel: String get() = formatMinutes(totalMinutes)
+}
+
+/**
+ * Groups sessions into months, preserving the order they arrive in: the agenda and the timeline
+ * both hand this a sorted list and expect the months back in that same direction.
+ *
+ * Lives here rather than in a controller because two pages now draw the same grouping, and a
+ * second copy is what would let their month headings or colours drift apart.
+ */
+fun groupByMonth(events: List<TrainingEvent>): List<TrainingMonthGroup> =
+    events.groupBy { YearMonth.from(it.startTime) }
+        .map { (month, monthEvents) ->
+            TrainingMonthGroup(
+                label = month.format(MONTH_LABEL),
+                rows = monthEvents.map { TrainingEventRow(it, TrainingEventPalette.swatchFor(it)) },
+                totalMinutes = monthEvents.sumOf { it.durationMinutes }
+            )
+        }

--- a/src/main/kotlin/com/jankowski/rafal/dancebook/dto/TrainingTimeline.kt
+++ b/src/main/kotlin/com/jankowski/rafal/dancebook/dto/TrainingTimeline.kt
@@ -1,0 +1,48 @@
+package com.jankowski.rafal.dancebook.dto
+
+/**
+ * One session on the timeline.
+ *
+ * [isFuture] separates what is still coming from what has already happened, which the page
+ * draws differently; [startsTodayBoundary] marks the single entry the "Today" divider sits
+ * above, so the template never has to compare dates itself.
+ */
+data class TrainingTimelineEntry(
+    val row: TrainingEventRow,
+    val isFuture: Boolean,
+    val startsTodayBoundary: Boolean
+) {
+    val event get() = row.event
+    val swatch get() = row.swatch
+}
+
+/** One month of the timeline, carrying the same totals the agenda shows. */
+data class TrainingTimelineMonth(
+    val label: String,
+    val entries: List<TrainingTimelineEntry>,
+    val totalMinutes: Long
+) {
+    val sessionCount: Int get() = entries.size
+
+    val sessionLabel: String get() = if (sessionCount == 1) "1 session" else "$sessionCount sessions"
+
+    val totalLabel: String get() = formatMinutes(totalMinutes)
+}
+
+/**
+ * One window of the timeline: newest first, oldest last.
+ *
+ * [lastMonthLabel] is echoed back on the next request so an appended window can tell whether
+ * its first month is a new one or a continuation of the month already on screen, and suppress
+ * a duplicate heading. [nextPage] is meaningless when [hasMore] is false.
+ */
+data class TrainingTimeline(
+    val months: List<TrainingTimelineMonth>,
+    val hasMore: Boolean,
+    val nextPage: Int,
+    val lastMonthLabel: String?,
+    /** True only for the very first window, which is the one that owns the empty state. */
+    val isFirstPage: Boolean
+) {
+    val isEmpty: Boolean get() = months.isEmpty()
+}

--- a/src/main/kotlin/com/jankowski/rafal/dancebook/repository/TrainingEventRepository.kt
+++ b/src/main/kotlin/com/jankowski/rafal/dancebook/repository/TrainingEventRepository.kt
@@ -3,6 +3,7 @@ package com.jankowski.rafal.dancebook.repository
 import com.jankowski.rafal.dancebook.model.AppUser
 import com.jankowski.rafal.dancebook.model.TrainingEvent
 import com.jankowski.rafal.dancebook.model.TrainingSeries
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
@@ -43,4 +44,20 @@ interface TrainingEventRepository : JpaRepository<TrainingEvent, UUID>, JpaSpeci
      */
     @EntityGraph(attributePaths = ["segments", "segments.danceCategory"])
     fun findAllByCreatedBy(createdBy: AppUser): List<TrainingEvent>
+
+    /**
+     * One window of the user's history, newest first — future sessions, then today, then the past.
+     *
+     * Carries no entity graph on purpose. Hibernate cannot paginate a collection fetch in SQL and
+     * falls back to loading everything and slicing in memory, which is exactly what the timeline's
+     * windowing exists to avoid; [findAllByIdIn] loads the segments for the window instead.
+     */
+    fun findAllByCreatedByOrderByStartTimeDesc(createdBy: AppUser, pageable: Pageable): List<TrainingEvent>
+
+    /**
+     * The second half of that two-step fetch: the same sessions again, with segments and their
+     * categories attached. An `IN` query has no inherent order, so the caller re-sorts.
+     */
+    @EntityGraph(attributePaths = ["segments", "segments.danceCategory"])
+    fun findAllByIdIn(ids: Collection<UUID>): List<TrainingEvent>
 }

--- a/src/main/kotlin/com/jankowski/rafal/dancebook/service/TrainingTimelineService.kt
+++ b/src/main/kotlin/com/jankowski/rafal/dancebook/service/TrainingTimelineService.kt
@@ -1,0 +1,10 @@
+package com.jankowski.rafal.dancebook.service
+
+import com.jankowski.rafal.dancebook.dto.TrainingTimeline
+
+/** One window of the signed-in user's training history, newest first. */
+interface TrainingTimelineService {
+
+    /** @param page zero-based; page 0 is the window that straddles today. */
+    fun timelineForCurrentUser(page: Int): TrainingTimeline
+}

--- a/src/main/kotlin/com/jankowski/rafal/dancebook/service/TrainingTimelineServiceImpl.kt
+++ b/src/main/kotlin/com/jankowski/rafal/dancebook/service/TrainingTimelineServiceImpl.kt
@@ -1,0 +1,104 @@
+package com.jankowski.rafal.dancebook.service
+
+import com.jankowski.rafal.dancebook.dto.TrainingTimeline
+import com.jankowski.rafal.dancebook.dto.TrainingTimelineEntry
+import com.jankowski.rafal.dancebook.dto.TrainingTimelineMonth
+import com.jankowski.rafal.dancebook.dto.groupByMonth
+import com.jankowski.rafal.dancebook.model.TrainingEvent
+import com.jankowski.rafal.dancebook.repository.TrainingEventRepository
+import org.slf4j.LoggerFactory
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+/**
+ * The training history as one scroll: what is coming, then today, then everything behind it.
+ *
+ * Unlike the statistics page this does not load the whole history — a timeline is read from the
+ * top and rarely to the end, so it is windowed and the older windows are fetched only if the user
+ * asks for them.
+ */
+@Service
+@Transactional(readOnly = true)
+class TrainingTimelineServiceImpl(
+    private val trainingEventRepository: TrainingEventRepository,
+    private val appUserService: AppUserService
+) : TrainingTimelineService {
+
+    companion object {
+        private val log = LoggerFactory.getLogger(TrainingTimelineServiceImpl::class.java)
+
+        /** Sessions per window. Roughly a season of twice-weekly training. */
+        const val PAGE_SIZE = 25
+    }
+
+    override fun timelineForCurrentUser(page: Int): TrainingTimeline {
+        val currentUser = appUserService.getCurrentUser()
+        log.debug("Building training timeline page {} for user '{}'", page, currentUser.username)
+
+        // One row beyond the window: if it comes back, there is another window behind this one.
+        // Cheaper and simpler than a second count query, and the extra row is never rendered.
+        val probed = trainingEventRepository.findAllByCreatedByOrderByStartTimeDesc(
+            currentUser,
+            PageRequest.of(page, PAGE_SIZE + 1)
+        )
+        val hasMore = probed.size > PAGE_SIZE
+        val window = probed.take(PAGE_SIZE)
+
+        val events = withSegments(window)
+
+        // One "now" for the whole window, so a render straddling midnight cannot place one
+        // session in the future and the next in the past by the same instant.
+        val now = LocalDateTime.now()
+        val months = toMonths(events, now, isFirstPage = page == 0)
+
+        return TrainingTimeline(
+            months = months,
+            hasMore = hasMore,
+            nextPage = page + 1,
+            lastMonthLabel = months.lastOrNull()?.label,
+            isFirstPage = page == 0
+        )
+    }
+
+    /**
+     * Re-reads the window through the entity graph so the page can draw each session's styles
+     * without a query per row. Paging and collection-fetching cannot go in one query — Hibernate
+     * would page in memory — so they go in two, and this one restores the order the `IN` lost.
+     */
+    private fun withSegments(window: List<TrainingEvent>): List<TrainingEvent> {
+        if (window.isEmpty()) return emptyList()
+        val ids = window.mapNotNull { it.id }
+        return trainingEventRepository.findAllByIdIn(ids).sortedByDescending { it.startTime }
+    }
+
+    /**
+     * Groups the window into months and marks the "today" divider.
+     *
+     * The divider belongs above the first session that is no longer ahead of us, and only on the
+     * first window: later windows are entirely in the past, so a second divider there would be a
+     * lie about where the present sits.
+     */
+    private fun toMonths(
+        events: List<TrainingEvent>,
+        now: LocalDateTime,
+        isFirstPage: Boolean
+    ): List<TrainingTimelineMonth> {
+        val boundary = if (isFirstPage) events.firstOrNull { !it.startTime.isAfter(now) } else null
+
+        return groupByMonth(events).map { group ->
+            TrainingTimelineMonth(
+                label = group.label,
+                entries = group.rows.map { row ->
+                    TrainingTimelineEntry(
+                        row = row,
+                        isFuture = row.event.startTime.isAfter(now),
+                        startsTodayBoundary = row.event === boundary
+                    )
+                },
+                totalMinutes = group.totalMinutes
+            )
+        }
+    }
+}

--- a/src/main/resources/frontend/input.css
+++ b/src/main/resources/frontend/input.css
@@ -391,6 +391,41 @@
   .tc-rail-weekday {
     @apply mt-1 text-[11px] font-semibold text-on-surface-variant;
   }
+
+  /* ── Training timeline ────────────────────────── */
+  /* A rule down the left with a node per session, so the eye can follow the sequence rather
+     than re-reading dates. The rule is narrow on a phone: the cards need the width more. */
+  .tc-timeline {
+    @apply relative space-y-gutter pl-6 sm:pl-8;
+  }
+  .tc-timeline::before {
+    @apply absolute inset-y-0 left-[7px] sm:left-[11px] w-px bg-outline-variant;
+    content: '';
+  }
+  .tc-timeline-item {
+    @apply relative;
+  }
+  /* Sits on the rule, filled with the session's own status colour. */
+  .tc-timeline-node {
+    @apply absolute -left-6 sm:-left-8 top-6 h-3.5 w-3.5 rounded-full border-2 bg-surface;
+  }
+  /* Nothing has happened yet, so the node is hollow rather than filled. */
+  .tc-timeline-node-future {
+    @apply bg-background;
+  }
+  /* Upcoming sessions read as provisional: a dashed edge, and they recede until hovered. */
+  .tc-timeline-upcoming {
+    @apply border-dashed opacity-80 transition-opacity hover:opacity-100;
+  }
+  /* Where the present sits in the scroll. */
+  .tc-timeline-today {
+    @apply relative -ml-6 sm:-ml-8 mb-gutter flex items-center gap-3 font-label-sm text-label-sm
+           font-bold uppercase tracking-wider text-primary;
+  }
+  .tc-timeline-today::after {
+    @apply h-px flex-1 bg-primary/40;
+    content: '';
+  }
 }
 
 /* ────────────────────────────────────────────────

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -51,6 +51,8 @@
                th:classappend="${activeNav == 'choreographies' ? 'text-primary bg-surface-container-high font-bold' : 'text-secondary hover:text-primary hover:bg-surface-container font-semibold'}">Choreographies</a>
             <a href="/training-events" class="font-body-md transition-all duration-200 px-4 py-2 rounded-full"
                th:classappend="${activeNav == 'training-events' ? 'text-primary bg-surface-container-high font-bold' : 'text-secondary hover:text-primary hover:bg-surface-container font-semibold'}">Training</a>
+            <a href="/training-events/timeline" class="font-body-md transition-all duration-200 px-4 py-2 rounded-full"
+               th:classappend="${activeNav == 'training-timeline' ? 'text-primary bg-surface-container-high font-bold' : 'text-secondary hover:text-primary hover:bg-surface-container font-semibold'}">Timeline</a>
             <a href="/profile" class="font-body-md transition-all duration-200 px-4 py-2 rounded-full"
                th:classappend="${activeNav == 'profile' ? 'text-primary bg-surface-container-high font-bold' : 'text-secondary hover:text-primary hover:bg-surface-container font-semibold'}">Profile</a>
         </nav>

--- a/src/main/resources/templates/training-events/calendar.html
+++ b/src/main/resources/templates/training-events/calendar.html
@@ -11,6 +11,10 @@
             <p class="page-subtitle md:hidden">Tap a day to read it. Tap + to add a session.</p>
         </div>
         <div class="flex items-center gap-2 shrink-0">
+            <a href="/training-events/timeline" class="btn-outline">
+                <span class="material-symbols-outlined text-[20px]">timeline</span>
+                Timeline
+            </a>
             <a href="/training-events/stats" class="btn-outline">
                 <span class="material-symbols-outlined text-[20px]">monitoring</span>
                 Stats

--- a/src/main/resources/templates/training-events/list.html
+++ b/src/main/resources/templates/training-events/list.html
@@ -10,6 +10,10 @@
             <p class="page-subtitle" th:text="${#lists.size(events)} + ' sessions logged'">0 sessions logged</p>
         </div>
         <div class="flex items-center gap-2 shrink-0">
+            <a href="/training-events/timeline" class="btn-outline">
+                <span class="material-symbols-outlined text-[20px]">timeline</span>
+                Timeline
+            </a>
             <a href="/training-events/stats" class="btn-outline">
                 <span class="material-symbols-outlined text-[20px]">monitoring</span>
                 Stats

--- a/src/main/resources/templates/training-events/stats.html
+++ b/src/main/resources/templates/training-events/stats.html
@@ -10,6 +10,10 @@
             <p class="page-subtitle" th:text="${stats.period.label}">All time</p>
         </div>
         <div class="flex items-center gap-2 shrink-0">
+            <a href="/training-events/timeline" class="btn-outline">
+                <span class="material-symbols-outlined text-[20px]">timeline</span>
+                Timeline
+            </a>
             <a href="/training-events" class="btn-outline">
                 <span class="material-symbols-outlined text-[20px]">list</span>
                 List

--- a/src/main/resources/templates/training-events/timeline.html
+++ b/src/main/resources/templates/training-events/timeline.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout :: html(content=~{::section})}">
+
+<section th:with="activeNav='training-timeline'" class="space-y-lg">
+
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+        <div class="page-header mb-0">
+            <h1 class="page-title text-3xl">Timeline</h1>
+            <p class="page-subtitle">Your training in order — what is coming, and everything behind it.</p>
+        </div>
+        <!-- The way back to the rest of the training pages. On a phone this cluster is the only
+             way here and away again: the bottom nav stays at six items on purpose. -->
+        <div class="flex items-center gap-2 shrink-0">
+            <a href="/training-events" class="btn-outline">
+                <span class="material-symbols-outlined text-[20px]">list</span>
+                Agenda
+            </a>
+            <a href="/training-events/stats" class="btn-outline">
+                <span class="material-symbols-outlined text-[20px]">monitoring</span>
+                Stats
+            </a>
+            <a href="/training-events/calendar" class="btn-outline">
+                <span class="material-symbols-outlined text-[20px]">calendar_month</span>
+                Calendar
+            </a>
+        </div>
+    </div>
+
+    <!-- The swap target is the fragment itself, so a window can replace the "load more" control
+         with the sessions it fetched plus the next control. -->
+    <div th:fragment="timelinePage" class="space-y-lg">
+
+        <div th:if="${timeline.isEmpty and timeline.isFirstPage}" class="empty-state">
+            <span class="material-symbols-outlined empty-state-icon">timeline</span>
+            <h3 class="empty-state-title">No training logged yet</h3>
+            <p class="empty-state-text">Once you log a session it will show up here, newest first.</p>
+            <a href="/training-events/new" class="btn-primary mt-4">Add Session</a>
+        </div>
+
+        <div th:each="month, monthStat : ${timeline.months}" class="space-y-gutter">
+
+            <!-- Suppressed when this window continues the month already on screen, so an
+                 appended page does not repeat a heading halfway down the timeline. -->
+            <div th:unless="${monthStat.first and month.label == continuedMonth}" class="tc-month-heading">
+                <h2 class="font-headline-md text-xl font-semibold text-on-surface" th:text="${month.label}">September 2026</h2>
+                <p class="font-body-md text-[14px] text-on-surface-variant tabular-nums">
+                    <span th:text="${month.sessionLabel}">6 sessions</span>
+                    <span class="text-outline"> · </span>
+                    <span th:text="${month.totalLabel}">9h 30m</span>
+                </p>
+            </div>
+
+            <!-- The connecting rule runs down the month; each session hangs a node off it. -->
+            <div class="tc-timeline">
+                <div th:each="entry : ${month.entries}" th:with="event=${entry.event}">
+
+                    <!-- Where the present sits. Drawn above the first session that is no longer
+                         ahead of us, and only on the first window. -->
+                    <div th:if="${entry.startsTodayBoundary}" class="tc-timeline-today">
+                        <span>Today</span>
+                    </div>
+
+                    <div class="tc-timeline-item">
+                        <span class="tc-timeline-node"
+                              th:classappend="${entry.isFuture} ? 'tc-timeline-node-future' : ''"
+                              th:style="'border-color:' + ${entry.swatch.color} + ';background-color:' + ${entry.swatch.tint}"
+                              aria-hidden="true"></span>
+
+                        <div class="card p-4 sm:p-5 flex items-start gap-3 sm:gap-4"
+                             th:classappend="${entry.isFuture} ? 'tc-timeline-upcoming' : ''">
+
+                            <!-- Date rail; the stripe and tint are the session's status. -->
+                            <div class="tc-rail"
+                                 th:style="'border-left-color:' + ${entry.swatch.color} + ';background-color:' + ${entry.swatch.tint}">
+                                <span class="tc-rail-day" th:text="${#temporals.format(event.startTime, 'd')}">10</span>
+                                <span class="tc-rail-weekday" th:text="${#temporals.format(event.startTime, 'EEE')}">Thu</span>
+                            </div>
+
+                            <div class="flex-1 min-w-0">
+                                <a th:href="@{/training-events/{id}(id=${event.id})}"
+                                   class="block truncate font-headline-lg text-base sm:text-lg font-semibold text-on-surface
+                                          hover:text-primary transition-colors"
+                                   th:text="${event.title}">Monday practice</a>
+
+                                <p class="font-body-md text-[14px] sm:text-body-md text-on-surface-variant mt-0.5 tabular-nums">
+                                    <span th:text="${#temporals.format(event.startTime, 'HH:mm')} + '–' + ${#temporals.format(event.endTime, 'HH:mm')}">18:00–20:00</span>
+                                    <span class="text-outline"> · </span>
+                                    <span th:text="${event.durationMinutes} + ' min'">120 min</span>
+                                </p>
+
+                                <div class="tc-badges mt-2">
+                                    <span class="badge-primary" th:text="${event.eventType}">TRAINING</span>
+
+                                    <span th:each="segment : ${event.segments}" class="badge-secondary"
+                                          th:text="${segment.danceCategory.name} + ' ' + ${segment.durationMinutes} + 'min'">Standard 60min</span>
+
+                                    <span th:if="${event.isAwaitingConfirmation}" class="badge-accent">Needs confirmation</span>
+
+                                    <span th:unless="${event.isAwaitingConfirmation}"
+                                          th:classappend="${event.attendanceStatus.name() == 'ATTENDED' ? 'badge-success' :
+                                                            event.attendanceStatus.name() == 'SKIPPED' ? 'badge-danger' : 'badge-neutral'}"
+                                          th:text="${entry.swatch.label}">Attended</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- An explicit control rather than a scroll trigger: the user asked for older history,
+             so they should be the one to ask. Replaces itself with the window it fetches. -->
+        <div th:if="${timeline.hasMore}" class="flex justify-center pt-2">
+            <button type="button" class="btn-outline"
+                    th:hx-get="@{/training-events/timeline(page=${timeline.nextPage},lastMonth=${timeline.lastMonthLabel})}"
+                    hx-target="this" hx-swap="outerHTML" hx-push-url="false">
+                <span class="material-symbols-outlined text-[20px]">history</span>
+                Load older sessions
+            </button>
+        </div>
+    </div>
+</section>
+</html>

--- a/src/test/kotlin/com/jankowski/rafal/dancebook/controller/web/TrainingEventWebControllerTest.kt
+++ b/src/test/kotlin/com/jankowski/rafal/dancebook/controller/web/TrainingEventWebControllerTest.kt
@@ -2,6 +2,7 @@ package com.jankowski.rafal.dancebook.controller.web
 
 import com.jankowski.rafal.dancebook.dto.TrainingEventPalette
 import com.jankowski.rafal.dancebook.dto.TrainingEventRequest
+import com.jankowski.rafal.dancebook.dto.TrainingMonthGroup
 import com.jankowski.rafal.dancebook.model.AttendanceStatus
 import com.jankowski.rafal.dancebook.model.DanceCategory
 import com.jankowski.rafal.dancebook.model.TrainingEvent

--- a/src/test/kotlin/com/jankowski/rafal/dancebook/controller/web/TrainingTimelineViewRenderingTest.kt
+++ b/src/test/kotlin/com/jankowski/rafal/dancebook/controller/web/TrainingTimelineViewRenderingTest.kt
@@ -1,0 +1,208 @@
+package com.jankowski.rafal.dancebook.controller.web
+
+import com.jankowski.rafal.dancebook.config.SecurityConfig
+import com.jankowski.rafal.dancebook.dto.TrainingEventPalette
+import com.jankowski.rafal.dancebook.dto.TrainingEventRow
+import com.jankowski.rafal.dancebook.dto.TrainingTimeline
+import com.jankowski.rafal.dancebook.dto.TrainingTimelineEntry
+import com.jankowski.rafal.dancebook.dto.TrainingTimelineMonth
+import com.jankowski.rafal.dancebook.model.AttendanceStatus
+import com.jankowski.rafal.dancebook.model.TrainingEvent
+import com.jankowski.rafal.dancebook.model.TrainingEventType
+import com.jankowski.rafal.dancebook.service.ActivityEventService
+import com.jankowski.rafal.dancebook.service.AppUserService
+import com.jankowski.rafal.dancebook.service.CustomListService
+import com.jankowski.rafal.dancebook.service.SystemSettingService
+import com.jankowski.rafal.dancebook.service.TrainingTimelineService
+import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.not
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration
+import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientWebSecurityAutoConfiguration
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.view
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * Renders the training timeline for real.
+ *
+ * TrainingTimelineServiceTest checks the ordering, the today boundary and the paging going into
+ * the model; none of that notices a template that asks the model for something it does not have,
+ * or a "load more" link that paginates to the wrong window. These do.
+ *
+ * Mirrors the TrainingStatsViewRenderingTest harness: same WebMvcTest slice shape, same
+ * NavbarAdvice mocks, same style of asserting on rendered body text.
+ */
+@WebMvcTest(
+    controllers = [TrainingTimelineWebController::class],
+    excludeAutoConfiguration = [
+        SecurityAutoConfiguration::class,
+        OAuth2ClientAutoConfiguration::class,
+        OAuth2ClientWebSecurityAutoConfiguration::class
+    ],
+    excludeFilters = [
+        ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [SecurityConfig::class])
+    ]
+)
+@AutoConfigureMockMvc(addFilters = false)
+class TrainingTimelineViewRenderingTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockBean private lateinit var trainingTimelineService: TrainingTimelineService
+
+    // Pulled in by NavbarAdvice, which supplies the layout's model on every page.
+    @MockBean private lateinit var customListService: CustomListService
+    @MockBean private lateinit var appUserService: AppUserService
+    @MockBean private lateinit var activityEventService: ActivityEventService
+    @MockBean private lateinit var systemSettingService: SystemSettingService
+
+    @Test
+    fun `renders the timeline with month headings, palette colours and the today marker`() {
+        `when`(trainingTimelineService.timelineForCurrentUser(anyInt())).thenReturn(
+            timeline(
+                month(
+                    "September 2026",
+                    entry(daysAgo = -3, status = AttendanceStatus.PLANNED),
+                    entry(daysAgo = 1, status = AttendanceStatus.SKIPPED, boundary = true)
+                )
+            )
+        )
+
+        mockMvc.perform(get("/training-events/timeline").with(csrf()))
+            .andExpect(status().isOk)
+            .andExpect(view().name("training-events/timeline"))
+            .andExpect(content().string(containsString("September 2026")))
+            // The rail's stripe is the session's own status colour, resolved server-side.
+            .andExpect(content().string(containsString("border-left-color:${TrainingEventPalette.SKIPPED.color}")))
+            .andExpect(content().string(containsString("tc-timeline-today")))
+            .andExpect(content().string(containsString("Skipped")))
+    }
+
+    @Test
+    fun `renders only the fragment for an HTMX request`() {
+        `when`(trainingTimelineService.timelineForCurrentUser(anyInt())).thenReturn(
+            timeline(month("August 2026", entry(daysAgo = 40, status = AttendanceStatus.ATTENDED)))
+        )
+
+        mockMvc.perform(
+            get("/training-events/timeline?page=1").header("HX-Request", "true").with(csrf())
+        )
+            .andExpect(status().isOk)
+            .andExpect(content().string(containsString("August 2026")))
+            // No page chrome: the fragment is an append, not a whole document.
+            .andExpect(content().string(not(containsString("<nav"))))
+    }
+
+    @Test
+    fun `suppresses the first month heading when it continues the month already on screen`() {
+        `when`(trainingTimelineService.timelineForCurrentUser(anyInt())).thenReturn(
+            timeline(month("August 2026", entry(daysAgo = 40, status = AttendanceStatus.ATTENDED)))
+        )
+
+        mockMvc.perform(
+            get("/training-events/timeline")
+                .param("page", "1")
+                .param("lastMonth", "August 2026")
+                .header("HX-Request", "true")
+                .with(csrf())
+        )
+            .andExpect(status().isOk)
+            .andExpect(content().string(not(containsString("tc-month-heading"))))
+    }
+
+    @Test
+    fun `offers the next window only when there is more history behind this one`() {
+        `when`(trainingTimelineService.timelineForCurrentUser(anyInt())).thenReturn(
+            timeline(
+                month("September 2026", entry(daysAgo = 1, status = AttendanceStatus.ATTENDED)),
+                hasMore = true,
+                nextPage = 1,
+                lastMonthLabel = "September 2026"
+            )
+        )
+
+        mockMvc.perform(get("/training-events/timeline").with(csrf()))
+            .andExpect(status().isOk)
+            .andExpect(content().string(containsString("Load older sessions")))
+            // The control carries the window to fetch and the month it continues.
+            .andExpect(content().string(containsString("page=1")))
+            .andExpect(content().string(containsString("lastMonth=September")))
+    }
+
+    @Test
+    fun `hides the next-window control at the end of the history`() {
+        `when`(trainingTimelineService.timelineForCurrentUser(anyInt())).thenReturn(
+            timeline(month("September 2026", entry(daysAgo = 1, status = AttendanceStatus.ATTENDED)))
+        )
+
+        mockMvc.perform(get("/training-events/timeline").with(csrf()))
+            .andExpect(status().isOk)
+            .andExpect(content().string(not(containsString("Load older sessions"))))
+    }
+
+    @Test
+    fun `shows the empty state when there is no training history at all`() {
+        `when`(trainingTimelineService.timelineForCurrentUser(anyInt())).thenReturn(timeline())
+
+        mockMvc.perform(get("/training-events/timeline").with(csrf()))
+            .andExpect(status().isOk)
+            .andExpect(content().string(containsString("No training logged yet")))
+    }
+
+    private fun timeline(
+        vararg months: TrainingTimelineMonth,
+        hasMore: Boolean = false,
+        nextPage: Int = 1,
+        lastMonthLabel: String? = months.lastOrNull()?.label,
+        isFirstPage: Boolean = true
+    ) = TrainingTimeline(
+        months = months.toList(),
+        hasMore = hasMore,
+        nextPage = nextPage,
+        lastMonthLabel = lastMonthLabel,
+        isFirstPage = isFirstPage
+    )
+
+    private fun month(label: String, vararg entries: TrainingTimelineEntry) = TrainingTimelineMonth(
+        label = label,
+        entries = entries.toList(),
+        totalMinutes = entries.sumOf { it.event.durationMinutes }
+    )
+
+    private fun entry(
+        daysAgo: Long,
+        status: AttendanceStatus,
+        boundary: Boolean = false
+    ): TrainingTimelineEntry {
+        val start = LocalDateTime.now().minusDays(daysAgo)
+        val event = TrainingEvent().apply {
+            id = UUID.randomUUID()
+            title = "Evening practice"
+            startTime = start
+            endTime = start.plusMinutes(90)
+            attendanceStatus = status
+            eventType = TrainingEventType.TRAINING
+        }
+        return TrainingTimelineEntry(
+            row = TrainingEventRow(event, TrainingEventPalette.swatchFor(event)),
+            isFuture = daysAgo < 0,
+            startsTodayBoundary = boundary
+        )
+    }
+}

--- a/src/test/kotlin/com/jankowski/rafal/dancebook/service/TrainingTimelineServiceTest.kt
+++ b/src/test/kotlin/com/jankowski/rafal/dancebook/service/TrainingTimelineServiceTest.kt
@@ -1,0 +1,262 @@
+package com.jankowski.rafal.dancebook.service
+
+import com.jankowski.rafal.dancebook.model.AppUser
+import com.jankowski.rafal.dancebook.model.AttendanceStatus
+import com.jankowski.rafal.dancebook.model.TrainingEvent
+import com.jankowski.rafal.dancebook.model.TrainingEventSegment
+import com.jankowski.rafal.dancebook.model.TrainingEventType
+import com.jankowski.rafal.dancebook.repository.TrainingEventRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyCollection
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.springframework.data.domain.Pageable
+import java.time.LocalDateTime
+import java.util.UUID
+
+class TrainingTimelineServiceTest {
+
+    private lateinit var trainingEventRepository: TrainingEventRepository
+    private lateinit var appUserService: AppUserService
+    private lateinit var trainingTimelineService: TrainingTimelineServiceImpl
+    private lateinit var currentUser: AppUser
+
+    @BeforeEach
+    fun setUp() {
+        trainingEventRepository = mock(TrainingEventRepository::class.java)
+        appUserService = mock(AppUserService::class.java)
+
+        currentUser = AppUser().apply {
+            id = UUID.randomUUID()
+            username = "tester"
+            displayName = "Test User"
+        }
+        `when`(appUserService.getCurrentUser()).thenReturn(currentUser)
+
+        trainingTimelineService = TrainingTimelineServiceImpl(trainingEventRepository, appUserService)
+    }
+
+    @Test
+    fun `orders upcoming sessions above past ones`() {
+        givenWindow(
+            event(daysAgo = -7, status = AttendanceStatus.PLANNED),
+            event(daysAgo = 1, status = AttendanceStatus.ATTENDED),
+            event(daysAgo = 40, status = AttendanceStatus.SKIPPED)
+        )
+
+        val timeline = trainingTimelineService.timelineForCurrentUser(page = 0)
+
+        val statuses = timeline.months.flatMap { it.entries }.map { it.event.attendanceStatus }
+        assertEquals(
+            listOf(AttendanceStatus.PLANNED, AttendanceStatus.ATTENDED, AttendanceStatus.SKIPPED),
+            statuses
+        )
+    }
+
+    @Test
+    fun `flags the today boundary on the first entry that is not in the future`() {
+        givenWindow(
+            event(daysAgo = -7, status = AttendanceStatus.PLANNED),
+            event(daysAgo = -2, status = AttendanceStatus.PLANNED),
+            event(daysAgo = 1, status = AttendanceStatus.ATTENDED),
+            event(daysAgo = 3, status = AttendanceStatus.ATTENDED)
+        )
+
+        val entries = trainingTimelineService.timelineForCurrentUser(page = 0)
+            .months.flatMap { it.entries }
+
+        assertEquals(listOf(true, true, false, false), entries.map { it.isFuture })
+        assertEquals(listOf(false, false, true, false), entries.map { it.startsTodayBoundary })
+    }
+
+    @Test
+    fun `marks no boundary when every session is still in the future`() {
+        givenWindow(
+            event(daysAgo = -7, status = AttendanceStatus.PLANNED),
+            event(daysAgo = -2, status = AttendanceStatus.PLANNED)
+        )
+
+        val entries = trainingTimelineService.timelineForCurrentUser(page = 0)
+            .months.flatMap { it.entries }
+
+        assertTrue(entries.all { it.isFuture })
+        assertTrue(entries.none { it.startsTodayBoundary })
+    }
+
+    @Test
+    fun `marks the boundary on the very first entry when nothing is upcoming`() {
+        givenWindow(
+            event(daysAgo = 1, status = AttendanceStatus.ATTENDED),
+            event(daysAgo = 3, status = AttendanceStatus.ATTENDED)
+        )
+
+        val entries = trainingTimelineService.timelineForCurrentUser(page = 0)
+            .months.flatMap { it.entries }
+
+        assertEquals(listOf(true, false), entries.map { it.startsTodayBoundary })
+    }
+
+    @Test
+    fun `the today boundary is only ever marked on the first window`() {
+        givenWindow(
+            event(daysAgo = 100, status = AttendanceStatus.ATTENDED),
+            event(daysAgo = 130, status = AttendanceStatus.SKIPPED)
+        )
+
+        val entries = trainingTimelineService.timelineForCurrentUser(page = 2)
+            .months.flatMap { it.entries }
+
+        assertTrue(entries.none { it.startsTodayBoundary })
+    }
+
+    @Test
+    fun `reports more to load when the window comes back full`() {
+        // One more than the page size: the probe row proves there is another window behind it.
+        val events = (1L..(TrainingTimelineServiceImpl.PAGE_SIZE + 1))
+            .map { event(daysAgo = it, status = AttendanceStatus.ATTENDED) }
+        givenWindow(*events.toTypedArray())
+
+        val timeline = trainingTimelineService.timelineForCurrentUser(page = 0)
+
+        assertTrue(timeline.hasMore)
+        assertEquals(1, timeline.nextPage)
+        // The probe row itself is not drawn.
+        assertEquals(
+            TrainingTimelineServiceImpl.PAGE_SIZE,
+            timeline.months.sumOf { it.entries.size }
+        )
+    }
+
+    @Test
+    fun `reports nothing more to load on a short window`() {
+        givenWindow(
+            event(daysAgo = 1, status = AttendanceStatus.ATTENDED),
+            event(daysAgo = 2, status = AttendanceStatus.SKIPPED)
+        )
+
+        val timeline = trainingTimelineService.timelineForCurrentUser(page = 0)
+
+        assertFalse(timeline.hasMore)
+        assertEquals(2, timeline.months.sumOf { it.entries.size })
+    }
+
+    @Test
+    fun `groups by month with session counts and wall-clock totals`() {
+        val now = LocalDateTime.now()
+        val sameMonth = now.withDayOfMonth(1).plusDays(1)
+        givenWindow(
+            eventAt(sameMonth.plusDays(2), AttendanceStatus.ATTENDED, minutes = 90),
+            eventAt(sameMonth, AttendanceStatus.ATTENDED, minutes = 30),
+            eventAt(sameMonth.minusMonths(1), AttendanceStatus.SKIPPED, minutes = 60)
+        )
+
+        val timeline = trainingTimelineService.timelineForCurrentUser(page = 0)
+
+        assertEquals(2, timeline.months.size)
+        assertEquals(2, timeline.months[0].sessionCount)
+        assertEquals("2 sessions", timeline.months[0].sessionLabel)
+        assertEquals(120L, timeline.months[0].totalMinutes)
+        assertEquals("2h", timeline.months[0].totalLabel)
+        assertEquals("1 session", timeline.months[1].sessionLabel)
+    }
+
+    @Test
+    fun `counts a session by its wall clock even when its segments are shorter`() {
+        // Segments skip warm-ups and breaks, so they may cover less than the session's slot.
+        val event = event(daysAgo = 1, status = AttendanceStatus.ATTENDED, minutes = 120).apply {
+            segments = mutableListOf(
+                TrainingEventSegment().apply {
+                    durationMinutes = 45
+                    sortOrder = 0
+                }
+            )
+        }
+        givenWindow(event)
+
+        val timeline = trainingTimelineService.timelineForCurrentUser(page = 0)
+
+        assertEquals(120L, timeline.months.single().totalMinutes)
+    }
+
+    @Test
+    fun `carries the last month rendered so the next window can continue it`() {
+        val now = LocalDateTime.now()
+        givenWindow(
+            eventAt(now.minusDays(1), AttendanceStatus.ATTENDED),
+            eventAt(now.minusMonths(2), AttendanceStatus.ATTENDED)
+        )
+
+        val timeline = trainingTimelineService.timelineForCurrentUser(page = 0)
+
+        assertEquals(timeline.months.last().label, timeline.lastMonthLabel)
+    }
+
+    @Test
+    fun `an empty history has no months and nothing to continue`() {
+        givenWindow()
+
+        val timeline = trainingTimelineService.timelineForCurrentUser(page = 0)
+
+        assertTrue(timeline.isEmpty)
+        assertFalse(timeline.hasMore)
+        assertNull(timeline.lastMonthLabel)
+        assertTrue(timeline.isFirstPage)
+    }
+
+    @Test
+    fun `carries the swatch so the page never re-derives a colour from a status`() {
+        givenWindow(event(daysAgo = 1, status = AttendanceStatus.SKIPPED))
+
+        val entry = trainingTimelineService.timelineForCurrentUser(page = 0)
+            .months.single().entries.single()
+
+        assertEquals("skipped", entry.swatch.key)
+    }
+
+    /**
+     * Stubs the two-step fetch: the window query returns the events in the order the database
+     * would, and the entity-graph re-read returns the same rows in an arbitrary order, which is
+     * what an `IN` query is entitled to do.
+     */
+    private fun givenWindow(vararg events: TrainingEvent) {
+        val ordered = events.sortedByDescending { it.startTime }
+        `when`(
+            trainingEventRepository.findAllByCreatedByOrderByStartTimeDesc(
+                any(AppUser::class.java) ?: currentUser,
+                any(Pageable::class.java) ?: Pageable.unpaged()
+            )
+        ).thenReturn(ordered)
+        `when`(trainingEventRepository.findAllByIdIn(anyCollection()))
+            .thenAnswer { invocation ->
+                val ids = invocation.getArgument<Collection<UUID>>(0).toSet()
+                ordered.filter { it.id in ids }.shuffled()
+            }
+    }
+
+    /** @param daysAgo negative values put the session in the future. */
+    private fun event(
+        daysAgo: Long,
+        status: AttendanceStatus,
+        minutes: Long = 60
+    ): TrainingEvent = eventAt(LocalDateTime.now().minusDays(daysAgo), status, minutes)
+
+    private fun eventAt(
+        start: LocalDateTime,
+        status: AttendanceStatus,
+        minutes: Long = 60
+    ): TrainingEvent = TrainingEvent().apply {
+        id = UUID.randomUUID()
+        title = "Session"
+        startTime = start
+        endTime = start.plusMinutes(minutes)
+        attendanceStatus = status
+        eventType = TrainingEventType.TRAINING
+        createdBy = currentUser
+    }
+}


### PR DESCRIPTION
Closes #38. Part of #35.

Training history was readable three ways — a month-grouped agenda, a calendar grid, and aggregate KPIs — and none of them answered "what has my training actually looked like, in order". This adds that single scroll: upcoming sessions, a marker for where the present sits, then everything behind it.

## Decisions

- **Own top-level nav entry, desktop only.** The route stays under `/training-events/timeline` so the calendar, agenda, stats and timeline remain one family of URLs, but it takes its own `activeNav` value (`training-timeline`, ordered above the `/training-events` branch since `when` takes the first match) — otherwise the "Training" link would light up instead of its own. The mobile bottom nav stays at six items: a seventh would crowd a `justify-around` phone row and undercut a page whose whole point is being mobile-first. On a phone the timeline is reached from the `btn-outline` cluster the training pages already share, which now carries a Timeline link on all four pages.
- **Windowed, with an explicit "load older sessions".** 25 sessions per window, newest first. A scroll trigger was rejected: nothing in the app does infinite scroll, and asking for older history should be the user's move.
- **Read-only.** Entries link through to the existing detail page; attendance marking stays on the agenda where it already works.

## Notes for review

**Paging is deliberately two queries.** `@EntityGraph` and `Pageable` on one method makes Hibernate give up on SQL pagination and slice a fully-loaded collection in memory (HHH90003004) — exactly what the windowing exists to avoid. So the window is paged without the graph, then re-read by id *with* it, and re-sorted because an `IN` query has no inherent order. An extra probe row stands in for a count query and is never rendered.

**The agenda's month grouping moved.** `groupByMonth`, `TrainingMonthGroup` and `TrainingEventRow` came out of `TrainingEventWebController` into `dto/`, so both pages share one grouping and one palette lookup. The KDoc there already recorded that a duplicated palette is how an earlier bug arose; a second copy of the grouping is how their headings or colours would drift apart next. `totalLabel` now delegates to the existing `formatMinutes` rather than re-implementing the same h/m formatting.

**One "now" per window.** The future/past split is computed from a single `LocalDateTime.now()`, so a render straddling midnight cannot place one session ahead of the present and the next behind it by the same instant — the same discipline `StatsPeriod.contains` enforces.

No entity change, so **no Flyway migration** (schema stays at V27). No new external script, so **no CSP edit**.

## Testing

`./gradlew build` passes: 156 tests, 0 failures across 24 suites.

- `TrainingTimelineServiceTest` (12 new) — ordering, the today boundary (including the cases where nothing is upcoming, nothing is past, and where a later window must not claim a second "today"), `hasMore` on full and short windows, month totals, wall-clock duration when segments are shorter than the slot.
- `TrainingTimelineViewRenderingTest` (6 new) — renders real Thymeleaf via the `@WebMvcTest` harness: month headings, the palette hex resolved server-side onto the rail, the Today marker, fragment-only output for HTMX, heading suppression on an appended window, and the load-more control appearing only when there is more history.
- `TrainingEventWebControllerTest` and `TrainingEventViewRenderingTest` are the regression check on the `dto` move and are unchanged apart from an import.

Not verified by booting the app — it needs the Google credentials and Postgres — so the template correctness here rests on the rendering tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)